### PR TITLE
Update BIFROST 3He monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,10 @@ their `McCode` representation and insert them into a `McStas` instrument by leve
 an `Assembler` from the `mccode_antlr` package.
 
 ```python
+from mccode_antlr import Flavor
 from mccode_antlr.assembler import Assembler
-from mccode_antlr.reader import MCSTAS_REGISTRY, GitHubRegistry
-from niess.bifrost.parameters import primary_parameters, known_channel_params
+from mccode_antlr.reader import GitHubRegistry
+from niess.bifrost.parameters import primary_parameters, tank_parameters
 from niess.bifrost import Primary, Tank
 
 registries = ['mcstas-chopper-lib', 'mcstas-transformer', 'mcstas-detector-tubes',
@@ -87,8 +88,8 @@ registries = [GitHubRegistry(
 ) for name in registries]
 
 
-assembler = Assembler('bifrost', registries=[MCSTAS_REGISTRY] + registries)
+assembler = Assembler('bifrost', registries=registries, flavor=Flavor.MCSTAS)
 Primary.from_calibration(primary_parameters()).to_mccode(assembler)
-Tank.from_calibration(known_channel_params()).to_mccode(assembler, 'sample_coordinates')
+Tank.from_calibration(tank_parameters()).to_mccode(assembler, 'sample_coordinates')
 
 ```

--- a/src/niess/bifrost/parameters.py
+++ b/src/niess/bifrost/parameters.py
@@ -39,12 +39,20 @@ def known_channel_params():
     known['contact_resistance'] = scalar(88.0/2, unit='Ohm')
     known['resistivity'] = scalar(185., unit='Ohm/in').to(unit='Ohm/m')
 
-    known['elastic_monitor_length'] = scalar(100., unit='mm')
-    known['elastic_monitor_width'] = scalar(10., unit='mm')
+    return known
+
+def tank_parameters():
+    from scipp import scalar
+    known = dict()
+    known['channels'] = known_channel_params()
     known['sample_elastic_monitor_distance'] = scalar(800., unit='mm')
     known['tank_elastic_monitor_angle'] = scalar(45., unit='deg')
-    known['elastic_monitor_pressure'] = scalar(10., unit='atm')
-
+    known['elastic_monitor'] = {
+        'name': 'elastic_monitor',
+        'radius': scalar(10., unit='mm'),
+        'length': scalar(100., unit='mm'),
+        'pressure': scalar(10., unit='atm'),
+    }
     return known
 
 

--- a/src/niess/bifrost/tank.py
+++ b/src/niess/bifrost/tank.py
@@ -4,20 +4,26 @@ from niess.components import He3Monitor
 
 
 def _elastic_monitor_from_params(params):
-    from scipp import scalar, vector
+    from scipp import vector
     from scipp.spatial import rotations_from_rotvecs
+    from .parameters import tank_parameters
+    tp = tank_parameters()
+    def par_or(par):
+        return tp[par] if par not in params else params[par]
+
     # There is a possibility that some or all necessary parameters are missing
     # but there are not always good defaults to provide in all cases. What do we do?
-    distance = params.get('sample_elastic_monitor_distance', scalar(0., unit='m'))
-    angle = params.get('tank_elastic_monitor_angle', scalar(0., unit='deg'))
-    length = params.get('elastic_monitor_length', scalar(0., unit='m'))
-    radius = params.get('elastic_monitor_radius', params.get('elastic_monitor_width', scalar(0., unit='m') / 2))
-    pressure = params.get('elastic_monitor_pressure', scalar(1., unit='atm'))
-    name = params.get('bragg_peak_monitor_name', 'diffraction_monitor')
+    distance = par_or('sample_elastic_monitor_distance')
+    angle = par_or('tank_elastic_monitor_angle')
     y, z = vector([0, 1, 0]), vector([0, 0, 1])
-    ori = rotations_from_rotvecs(y * angle) # is this the orientation of the monitor too?
-    pos = ori * (z * distance)
-    return He3Monitor(name, pos, ori, radius, length, pressure)
+    ori = rotations_from_rotvecs(y * angle)  # is this the monitor orientation too?
+
+    cal = par_or('elastic_monitor')
+    cal['name'] = cal.get('name', 'elastic_monitor')
+    cal['position'] = cal.get('position', ori * (z * distance))
+    cal['orientation'] = cal.get('orientation', ori)
+
+    return He3Monitor.from_calibration(cal)
 
 
 @dataclass
@@ -32,10 +38,11 @@ class Tank:
 
     @staticmethod
     @calibration
-    def from_calibration(params: dict):
-        from scipp import array, scalar
+    def from_calibration(cal: dict):
+        from scipp import array
         from .channel import Channel
-
+        from .parameters import known_channel_params
+        params = cal.get('channels', known_channel_params())
         channel_params = [{'variant': x} for x in ('s', 'm', 'l')]
         channel_params = {i: channel_params[i % 3] for i in range(9)}
         # but this can be overridden by specifying an integer-keyed dictionary with the parameters for each channel
@@ -45,7 +52,7 @@ class Tank:
                             array(values=[-40, -30, -20, -10, 0, 10, 20, 30, 40.], unit='degree', dims=['channel']))
 
         channels = [Channel.from_calibration(angles[i], **channel_params[i]) for i in range(9)]
-        return Tank(tuple(channels), _elastic_monitor_from_params(params))
+        return Tank(tuple(channels), _elastic_monitor_from_params(cal))
 
     @staticmethod
     def unique_from_calibration(**params):

--- a/src/niess/bifrost/tank.py
+++ b/src/niess/bifrost/tank.py
@@ -1,31 +1,23 @@
 from dataclasses import dataclass
 from niess.utilities import calibration
-
-from niess import He3Tube
-
-def _tube_at(distance, rotation_y, length, radius, resistivity, elements, pressure):
-    from scipp import vector
-    from scipp.spatial import rotations_from_rotvecs
-    y, z = vector([0, 1, 0]), vector([0, 0, 1])
-    r = rotations_from_rotvecs(y * rotation_y)
-    pos = r * (z * distance)
-    top = pos + length * y / 2
-    bottom = pos - length * y / 2
-    return He3Tube(at=bottom, to=top, radius=radius, resistivity=resistivity, elements=elements, pressure=pressure)
+from niess.components import He3Monitor
 
 
 def _elastic_monitor_from_params(params):
-    from scipp import scalar
+    from scipp import scalar, vector
+    from scipp.spatial import rotations_from_rotvecs
     # There is a possibility that some or all necessary parameters are missing
     # but there are not always good defaults to provide in all cases. What do we do?
     distance = params.get('sample_elastic_monitor_distance', scalar(0., unit='m'))
     angle = params.get('tank_elastic_monitor_angle', scalar(0., unit='deg'))
     length = params.get('elastic_monitor_length', scalar(0., unit='m'))
     radius = params.get('elastic_monitor_radius', params.get('elastic_monitor_width', scalar(0., unit='m') / 2))
-    resistivity = scalar(1., unit='Ohm/cm')
     pressure = params.get('elastic_monitor_pressure', scalar(1., unit='atm'))
-    mon = _tube_at(distance, angle, length, radius, resistivity, 1, pressure)
-    return mon
+    name = params.get('bragg_peak_monitor_name', 'diffraction_monitor')
+    y, z = vector([0, 1, 0]), vector([0, 0, 1])
+    ori = rotations_from_rotvecs(y * angle) # is this the orientation of the monitor too?
+    pos = ori * (z * distance)
+    return He3Monitor(name, pos, ori, radius, length, pressure)
 
 
 @dataclass
@@ -36,7 +28,7 @@ class Tank:
     from mccode_antlr.instr import Instance
 
     channels: tuple[Channel, ...]
-    monitor: He3Tube
+    monitor: He3Monitor
 
     @staticmethod
     @calibration
@@ -145,3 +137,7 @@ class Tank:
             when = f"{1 + index} == secondary_cassette"
             channel.to_mccode(assembler, sample, name=name, when=when, settings=settings, **kwargs)
 
+        # only if a ray did not enter one of the channels does it have any chance
+        # of hitting the Bragg peak monitor:
+        mon = self.monitor.to_mccode(assembler)
+        mon.WHEN('secondary_cassette == -1')

--- a/src/niess/components/__init__.py
+++ b/src/niess/components/__init__.py
@@ -8,7 +8,7 @@ from .component import Component
 from .filter import Attenuator, Filter, OrderedFilter, make_aluminum
 from .guide import EllipticGuide, TaperedGuide, StraightGuide, Guide, StraightGuides, TaperedGuides
 from .moderator import Moderator
-from .monitors import FissionChamber, BeamCurrentMonitor, GEM2D
+from .monitors import FissionChamber, He3Monitor, BeamCurrentMonitor, GEM2D
 from .source import ESSource
 from .section import Section
 
@@ -43,6 +43,7 @@ __all__ = [
     TaperedGuides,
     Moderator,
     FissionChamber,
+    He3Monitor,
     BeamCurrentMonitor,
     GEM2D,
     ESSource,

--- a/src/niess/components/monitors.py
+++ b/src/niess/components/monitors.py
@@ -75,6 +75,39 @@ class FissionChamber(Component):
         # Build the NeXus Structure entry to point to the correct Kafka stream
         return add_frame_monitor_metadata(inst, self.__mccode__()[1]['nt'])
 
+@dataclass
+class He3Monitor(Component):
+    """Zero-dimensional He3 tube monitor.
+    Outputs events without any spatial information.
+    """
+    radius: Variable
+    length: Variable
+    pressure: Variable
+
+    @classmethod
+    def from_calibration(cls, cal: dict):
+        name = cal['name']
+        position = cal['position']
+        orientation = cal['orientation']
+        radius = cal['radius']
+        length = cal['length']
+        pressure = cal['pressure']
+        return cls(name, position, orientation, radius, length, pressure)
+
+    def __mccode__(self) -> tuple[str, dict]:
+        p = {
+            'xwidth': 2 * self.radius.to(unit='m').value,
+            'yheight': self.length.to(unit='m').value,
+            'nt': int(1e6 / 14.0 / 7),  # 7 microsecond bins
+            'frequency': 14.0,
+        }
+        return 'Frame_monitor', p
+
+    def to_mccode(self, assembler: Assembler):
+        inst = super().to_mccode(assembler)
+        # Build the NeXus Structure entry to point to the correct Kafka stream
+        return add_frame_monitor_metadata(inst, self.__mccode__()[1]['nt'])
+
 
 @dataclass
 class BeamCurrentMonitor(Component):

--- a/tests/test_bifrost.py
+++ b/tests/test_bifrost.py
@@ -21,17 +21,15 @@ def get_mccode_registries():
 
 
 def test_bifrost_whole():
-    from niess.bifrost.parameters import primary_parameters
-    from niess.bifrost.parameters import known_channel_params
+    from niess.bifrost.parameters import primary_parameters, tank_parameters
     from niess.bifrost import Tank, Primary
 
     primary = Primary.from_calibration(primary_parameters())
-    tank = Tank.from_calibration(**known_channel_params())
+    tank = Tank.from_calibration(tank_parameters())
 
 
 def test_bifrost_mccode():
-    from niess.bifrost.parameters import primary_parameters
-    from niess.bifrost.parameters import known_channel_params
+    from niess.bifrost.parameters import primary_parameters, tank_parameters
     from niess.bifrost import Tank, Primary
     from mccode_antlr import Flavor
     from mccode_antlr.assembler import Assembler
@@ -46,7 +44,7 @@ def test_bifrost_mccode():
     #      any filters, e.g., a hits-the-sample MCPL filter, or a Be-transmission filter
     #      the radial collimator between sample and tank, etc.
 
-    tank = Tank.from_calibration(**known_channel_params())
+    tank = Tank.from_calibration(tank_parameters())
     tank.to_mccode(bifrost, 'sample_origin')
 
     # TODO add checks that conversion from the intermediate representation works?

--- a/tests/test_bifrost_tank.py
+++ b/tests/test_bifrost_tank.py
@@ -21,15 +21,16 @@ def test_bifrost_tank_constructable():
 def test_bifrost_tank_calibratable():
     from scipp import scalar, isclose
     from niess.bifrost import Tank
-    from niess.bifrost.parameters import known_channel_params
-    params = known_channel_params()
-    tank = Tank.from_calibration(**params)
+    from niess.bifrost.parameters import tank_parameters
+    calibration = tank_parameters()
+    tank = Tank.from_calibration(calibration)
 
     assert len(tank.channels) == 9
 
     vertical = 4.0, 3.674467758121384, 3.372105326299701, 3.1338895319560107, 2.9399369139099463
     horizontal = scalar(5.2, unit='deg')
 
+    params = calibration['channels']
     for channel in tank.channels:
         assert len(channel.pairs) == 5
         for index, (analyzer, triplet) in enumerate((arm.analyzer, arm.detector) for arm in channel.pairs):
@@ -71,9 +72,12 @@ def test_bifrost_tank_angles():
     scattering limit boundaries for a single setting of the tank position"""
     from scipp import vector, concat, scalar
     from niess.bifrost import Tank
-    from niess.bifrost.parameters import known_channel_params
-    params = known_channel_params()
-    tank = Tank.from_calibration(**params)
+    from niess.bifrost.parameters import tank_parameters
+    params = tank_parameters()
+    assert 'channels' in params
+    assert 'elastic_monitor' in params
+
+    tank = Tank.from_calibration(params)
 
     sample = vector(value=[0, 0, 0], unit='m')
 


### PR DESCRIPTION
The 3He Bragg peak monitor on BIFROST is now output to the McStas instrument.
There are minor changes to how the `Tank` calibration parameter dictionary is laid out, with the channel information now required in a nested 'channels' dictionary instead of at the top level.