### PR TITLE
Replace `dataclass` by `msgspec.Struct`, add JSON and other serializers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,11 +24,12 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "scipp>=25.1.0",
+  "scipp>=25.8.0",
   "numpy",
   "scipy",
-  "mccode-antlr>=0.14.0",
+  "mccode-antlr>=0.15.2",
   "mccode-to-kafka>=0.2.2",
+  "msgspec>=0.19.0"
 ]
 
 [project.urls]

--- a/src/niess/bifrost/analyzer.py
+++ b/src/niess/bifrost/analyzer.py
@@ -1,13 +1,23 @@
-from dataclasses import dataclass
+from niess.components.component import Base
+from typing import ClassVar, Type
 
-
-@dataclass
-class Analyzer:
+class Analyzer(Base):
     from mccode_antlr.assembler import Assembler
     from ..components import Crystal
     from scipp import Variable
 
     blades: tuple[Crystal, ...]  # 7-9 blades
+
+    __struct_field_types__: ClassVar[dict[str, Type]] = {'blades': tuple[Crystal, ...]}
+
+    @classmethod
+    def from_dict(cls, data):
+        from ..components import Crystal
+        blades = data['blades']
+        if not hasattr(blades, '__len__') or (len(blades) != 7 and len(blades) != 9):
+            raise ValueError('Blades must have 7 or 9 elements')
+        blades = tuple(b if isinstance(b, Crystal) else Crystal.from_dict(b) for b in blades)
+        return cls(blades)
 
     @property
     def central_blade(self):

--- a/src/niess/bifrost/arm.py
+++ b/src/niess/bifrost/arm.py
@@ -1,7 +1,7 @@
-from dataclasses import dataclass
+from niess.components.component import Base
+from typing import ClassVar, Type
 
-@dataclass
-class Arm:
+class Arm(Base):
     from mccode_antlr.assembler import Assembler
     from mccode_antlr.instr import Instance
     from .analyzer import Analyzer
@@ -10,6 +10,20 @@ class Arm:
 
     analyzer: Analyzer
     detector: Triplet
+
+    __struct_field_types__: ClassVar[dict[str, Type]] = {'analyzer': Analyzer, 'detector': Triplet}
+
+    @classmethod
+    def from_dict(cls, data):
+        from .analyzer import Analyzer
+        from .triplet import Triplet
+        analyzer = data['analyzer']
+        detector = data['detector']
+        if not isinstance(analyzer, Analyzer):
+            analyzer = Analyzer.from_dict(analyzer)
+        if not isinstance(detector, Triplet):
+            detector = Triplet.from_dict(detector)
+        return cls(analyzer, detector)
 
     @staticmethod
     def from_calibration(a_position, tau, d_position, d_length, **params):

--- a/src/niess/bifrost/channel.py
+++ b/src/niess/bifrost/channel.py
@@ -1,5 +1,5 @@
-from dataclasses import dataclass
-
+from typing import ClassVar, Type
+from niess.components.component import Base
 
 def variant_parameters(params: dict, default: dict):
     variant = params.get('variant', default['variant'])
@@ -7,14 +7,25 @@ def variant_parameters(params: dict, default: dict):
     return complete
 
 
-@dataclass
-class Channel:
+
+class Channel(Base):
     from mccode_antlr.assembler import Assembler
     from mccode_antlr.instr import Instance
     from scipp import Variable
     from .arm import Arm
 
     pairs: tuple[Arm, Arm, Arm, Arm, Arm]
+
+    __struct_field_types__: ClassVar[dict[str, Type]] = {'pairs': tuple[Arm, Arm, Arm, Arm, Arm]}
+
+    @classmethod
+    def from_dict(cls, data):
+        from .arm import Arm
+        pairs = data['pairs']
+        if not hasattr(pairs, '__len__') or len(pairs) != 5:
+            raise ValueError(f'Blades must have 5 elements (not {len(pairs)})')
+        pairs = tuple(p if isinstance(p, Arm) else Arm.from_dict(p) for p in pairs)
+        return cls(pairs)
 
     @staticmethod
     def from_calibration(relative_angle: Variable, **params):

--- a/src/niess/bifrost/primary.py
+++ b/src/niess/bifrost/primary.py
@@ -6,7 +6,6 @@ series of sections, each of which performs a specific function.
 Each section contains a mixture of guide elements, choppers, monitors, attenuators,
 windows, etc.; but they all come together into the primary spectrometer.
 """
-from dataclasses import dataclass
 from ..components import (
     Section, Component,
     Jaw, Slit, Filter, Attenuator, DiscChopper,
@@ -15,8 +14,146 @@ from ..components import (
 )
 from ..utilities import calibration
 
-@dataclass
+PRIMARY_TYPES = {
+    'source': ESSource,
+    # compressor section
+    'nboa_entry_window': Filter,
+    'nboa': EllipticGuide,  # Neutron Beam Optics Assembly
+    'nboa_exit_window': Filter,
+    'monolith_window': Filter,
+    'bbg_entry_window': Filter,
+    'bbg': EllipticGuide,  # Bridge Beam Guide
+    'bbg_exit_window': Filter,
+    'psc_housing_entry_window': Filter,
+    'nose': EllipticGuide,
+    # pulse shaping choppers (not in a named section ...)
+    'pulse_shaping_chopper_1': DiscChopper,
+    'pulse_shaping_chopper_2': DiscChopper,
+    # curved guide section
+    'unit_3_curved': StraightGuides,
+    'psc_exit_window': Filter,
+    'psc_monitor': FissionChamber,
+    'curved_entrance_window': Filter,
+    'unit_4_curved': StraightGuides,
+    'unit_4_exit_window': Filter,
+    'frame_overlap_chopper_1': DiscChopper,
+    'unit_5_entry_window': Filter,
+    'unit_5_curved': StraightGuides,
+    'unit_6_curved': StraightGuides,
+    'unit_7_curved': StraightGuides,
+    'unit_8_curved': StraightGuides,
+    'unit_8_exit_window': Filter,
+    'frame_overlap_chopper_2': DiscChopper,
+    'unit_9_entry_window': Filter,
+    'unit_9_curved': StraightGuides,
+    'unit_10_curved': StraightGuides,
+    'unit_11_curved': StraightGuides,
+    'unit_12_curved': StraightGuides,
+    'unit_13_curved': StraightGuides,
+    'unit_14_curved': StraightGuides,
+    'unit_15_curved': StraightGuides,
+    # expanding guide section
+    'unit_16_bw_insert': EllipticGuide,  # Bunker wall insert, first part
+    'unit_17_bw_insert': EllipticGuide,  # Bunker wall insert, second part
+    'unit_17_exit_window': Filter,
+    'overlap_monitor': BeamCurrentMonitor,
+    'unit_18_entry_window': Filter,
+    'unit_18_expanding': EllipticGuide,
+    'unit_19_expanding': EllipticGuide,
+    'unit_20_expanding': EllipticGuide,
+    'unit_21_expanding': EllipticGuide,
+    'unit_22_expanding': EllipticGuide,
+    'unit_23_expanding': EllipticGuide,
+    'unit_24_expanding': EllipticGuide,
+    'unit_25_expanding': EllipticGuide,
+    'unit_26_expanding': EllipticGuide,
+    'unit_27_expanding': EllipticGuide,
+    'unit_28_expanding': EllipticGuide,
+    'unit_28_exit_window': Filter,
+    # straight guide transport section
+    'unit_29_entry_window': Filter,
+    'unit_29_straight': StraightGuide,
+    'unit_30_straight': StraightGuide,
+    'unit_31_straight': StraightGuide,
+    'unit_32_straight': StraightGuide,
+    'unit_33_straight': StraightGuide,
+    'unit_34_straight': StraightGuide,
+    'unit_35_straight': StraightGuide,
+    'unit_36_straight': StraightGuide,
+    'unit_37_straight': StraightGuide,
+    'unit_38_straight': StraightGuide,
+    'unit_39_straight': StraightGuide,
+    'unit_40_straight': StraightGuide,
+    'unit_41_straight': StraightGuide,
+    'unit_42_straight': StraightGuide,
+    'unit_43_straight': StraightGuide,
+    'bandwidth_chopper_1': DiscChopper,
+    'bandwidth_chopper_2': DiscChopper,
+    'unit_43_exit_window': Filter,
+    'bandwidth_monitor': BeamCurrentMonitor,
+    'attenuator_1': Attenuator,
+    'attenuator_2': Attenuator,
+    'attenuator_3': Attenuator,
+    'unit_44_entry_window': Filter,
+    'unit_44_straight': StraightGuide,
+    'unit_45_straight': StraightGuide,
+    'unit_46_straight': StraightGuide,
+    'unit_47_straight': StraightGuide,
+    'unit_48_straight': StraightGuide,
+    'unit_49_straight': StraightGuide,
+    'unit_50_straight': StraightGuide,
+    'unit_51_straight': StraightGuide,
+    'unit_52_straight': StraightGuide,
+    'unit_53_straight': StraightGuide,
+    'unit_54_straight': StraightGuide,
+    'unit_55_straight': StraightGuide,
+    'unit_56_straight': StraightGuide,
+    'unit_57_straight': StraightGuide,
+    'unit_58_straight': StraightGuide,
+    'unit_59_straight': StraightGuide,
+    'unit_60_straight': StraightGuide,
+    'unit_61_straight': StraightGuide,
+    'unit_62_straight': StraightGuide,
+    'unit_63_straight': StraightGuide,
+    'unit_64_straight': StraightGuide,
+    'unit_65_straight': StraightGuide,
+    'unit_66_straight': StraightGuide,
+    'unit_67_straight': StraightGuide,
+    'unit_68_straight': StraightGuide,
+    'unit_69_straight': StraightGuide,
+    'unit_70_straight': StraightGuide,
+    'unit_71_straight': StraightGuide,
+    'unit_72_straight': StraightGuide,
+    'unit_73_straight': StraightGuide,
+    'unit_74_straight': StraightGuide,
+    'unit_75_straight': StraightGuide,
+    # focusing section
+    'unit_76_closing': EllipticGuide,
+    'unit_77_closing': EllipticGuide,
+    'unit_78_closing': EllipticGuide,
+    'unit_79_closing': EllipticGuide,
+    'unit_80_closing': EllipticGuide,
+    'unit_81_closing': EllipticGuide,
+    'unit_82_closing': EllipticGuide,
+    'unit_83_closing': EllipticGuide,
+    'unit_84_closing': EllipticGuide,
+    'unit_85_closing': EllipticGuide,
+    'jaw_3': Jaw,
+    'unit_86_closing': EllipticGuide,
+    'jaw_2': Jaw,
+    'unit_87_closing': EllipticGuide,
+    'jaw_1': Jaw,
+    'unit_88_closing': EllipticGuide,
+    'unit_88_exit_window': Filter,
+    'mask': Slit,
+    'normalization_monitor': GEM2D,
+    'slit': Slit,
+    'sample_origin': Component,
+}
+
 class Primary(Section):
+    __struct_field_types__ = PRIMARY_TYPES  # an inconvenient hack
+
     source: ESSource
 
     # compressor section
@@ -167,3 +304,5 @@ class Primary(Section):
         if len(parameters) == 0:
             parameters = primary_parameters()
         return super().from_calibration(parameters)
+
+

--- a/src/niess/bifrost/tank.py
+++ b/src/niess/bifrost/tank.py
@@ -1,7 +1,7 @@
-from dataclasses import dataclass
+from typing import ClassVar, Type
 from niess.utilities import calibration
 from niess.components import He3Monitor
-
+from niess.components.component import Base
 
 def _elastic_monitor_from_params(params):
     from scipp import vector
@@ -26,8 +26,7 @@ def _elastic_monitor_from_params(params):
     return He3Monitor.from_calibration(cal)
 
 
-@dataclass
-class Tank:
+class Tank(Base):
     from scipp import Variable
     from .channel import Channel
     from mccode_antlr.assembler import Assembler
@@ -35,6 +34,20 @@ class Tank:
 
     channels: tuple[Channel, ...]
     monitor: He3Monitor
+
+    __struct_field_types__: ClassVar[dict[str, Type]] = {'channels': tuple[Channel, ...], 'monitor': He3Monitor}
+
+    @classmethod
+    def from_dict(cls, data):
+        from .channel import Channel
+        cs = data['channels']
+        if not hasattr(cs, '__len__'):
+            raise ValueError('Channels must have length (probably 9)')
+        cs = tuple(c if isinstance(c, Channel) else Channel.from_dict(c) for c in cs)
+        mn = data['monitor']
+        if not isinstance(mn, He3Monitor):
+            mn = He3Monitor.from_dict(mn)
+        return cls(cs, mn)
 
     @staticmethod
     @calibration
@@ -148,3 +161,4 @@ class Tank:
         # of hitting the Bragg peak monitor:
         mon = self.monitor.to_mccode(assembler)
         mon.WHEN('secondary_cassette == -1')
+

--- a/src/niess/bifrost/triplet.py
+++ b/src/niess/bifrost/triplet.py
@@ -1,19 +1,32 @@
-from dataclasses import dataclass
-
+from niess.components.component import Base
 
 def __is_type__(x, t, name):
     if not isinstance(x, t):
         raise RuntimeError(f"{name} must be a {t}")
 
 
-@dataclass
-class Triplet:
+class Triplet(Base):
     from mccode_antlr.assembler import Assembler
     from ..components import He3Tube
     from scipp import Variable
 
     tubes: tuple[He3Tube, He3Tube, He3Tube]
     resistances: Variable
+
+    __struct_field_types__ = {'tubes': tuple[He3Tube, He3Tube, He3Tube],
+                              'resistances': Variable}
+
+    @classmethod
+    def from_dict(cls, data):
+        from ..components import He3Tube
+        tubes = data['tubes']
+        resistances = data['resistances']
+        if not isinstance(tubes, tuple) and isinstance(tubes, list):
+            tubes = tuple(tubes)
+        if not len(tubes) == 3:
+            raise RuntimeError(f"3 tubes required (not {len(tubes)})")
+        tubes = tuple(t if isinstance(t, He3Tube) else He3Tube.from_dict(t) for t in tubes)
+        return cls(tubes, resistances)
 
     @staticmethod
     def from_calibration(position: Variable, length: Variable, **params):

--- a/src/niess/components/aperture.py
+++ b/src/niess/components/aperture.py
@@ -1,9 +1,8 @@
-from dataclasses import dataclass
 from scipp import Variable
 from mccode_antlr.assembler import Assembler
 from .component import Component
 
-@dataclass
+
 class Aperture(Component):
     width: Variable
     height: Variable
@@ -18,7 +17,6 @@ class Aperture(Component):
         return cls(name, position, orientation, width, height)
 
 
-@dataclass
 class Jaw(Aperture):
     """A special variable width aperture, open by default and configured at runtime"""
 
@@ -38,7 +36,6 @@ class Jaw(Aperture):
         return super().to_mccode(assembler)
 
 
-@dataclass
 class Slit(Aperture):
     """A special variable aperture, open by default and configured at runtime"""
 

--- a/src/niess/components/chopper.py
+++ b/src/niess/components/chopper.py
@@ -1,10 +1,9 @@
-from dataclasses import dataclass
 from scipp import Variable
 from .component import Component
 
 from mccode_antlr.assembler import Assembler
 
-@dataclass
+
 class Chopper(Component):
     """Any device which periodically opens a path that particles may traverse"""
     velocity: Variable  # angular velocity scalar or vector
@@ -15,7 +14,6 @@ class Chopper(Component):
     height: Variable  # the path height
 
 
-@dataclass
 class DiscChopper(Chopper):
     """Ideally infinitely thin material with rotation vector parallel to the path"""
     # `radius` is the outer dimension of the disc.
@@ -93,7 +91,6 @@ class DiscChopper(Chopper):
         return super().to_mccode(assembler)
 
 
-@dataclass
 class FermiChopper(Chopper):
     """Ideally infinitely tall cylinder with a group of curved channels through
     its center, rotation vector parallel to its axis, and perpendicular to the path"""

--- a/src/niess/components/collimator.py
+++ b/src/niess/components/collimator.py
@@ -1,9 +1,7 @@
-from dataclasses import dataclass
 from scipp import Variable
 from .component import Component
 
 
-@dataclass
 class Collimator(Component):
     """A device which limits the horizontal divergence and/or scattering kernel size"""
     width: Variable
@@ -12,13 +10,11 @@ class Collimator(Component):
     blades: int  # number of infinitely thin blades that fit within width
 
 
-@dataclass
 class SollerCollimator(Collimator):
     """Collimator with linear width, height, and length"""
     pass
 
 
-@dataclass
 class RadialCollimator(Collimator):
     """Collimator with angular width, linear height, and radial length"""
     radius: Variable  # the inner radius of the collimator blades

--- a/src/niess/components/component.py
+++ b/src/niess/components/component.py
@@ -1,10 +1,46 @@
-from dataclasses import dataclass
+import msgspec
+from typing import ClassVar, Type
 from scipp import Variable
 from mccode_antlr.assembler import Assembler
 
+class Base(msgspec.Struct):
+    __struct_field_types__: ClassVar[dict[str, Type]]
 
-@dataclass
-class Component:
+    def to_dict(self):
+        return {k: getattr(self, k) for k in self.__struct_fields__}
+
+    @classmethod
+    def from_dict(cls, data):
+        for k, t in cls.__struct_field_types__.items():
+            if k not in data:
+                raise KeyError(f"{k} not found in data")
+            if not isinstance(data[k], t) and isinstance(data[k], dict) and hasattr(t, 'from_dict'):
+                data[k] = t.from_dict(data[k])
+        return cls(**data)
+
+    def fields(self):
+        return self.__struct_fields__
+
+    def __eq__(self, other):
+        from scipp import identical
+        if not isinstance(other, type(self)):
+            return False
+        for field in self.__struct_fields__:
+            a = getattr(self, field)
+            b = getattr(other, field)
+            if a is None or b is None:
+                if a is not None or b is not None:
+                    return False
+            elif isinstance(a, Variable):
+                if not identical(a, b, equal_nan=True):
+                    return False
+            else:
+                if a != b:
+                    return False
+        return True
+
+
+class Component(Base):
     """Any component in the instrument.
 
     Note
@@ -34,6 +70,10 @@ class Component:
         position = calibration['position']
         orientation = calibration['orientation']
         return cls(name, position, orientation)
+
+    @classmethod
+    def from_dict(cls, dictionary):
+        return cls.from_calibration(dictionary)
 
     def __mccode__(self) -> tuple[str, dict]:
         """Return the component type name and parameters needed to produce a McCode instance"""

--- a/src/niess/components/crystals.py
+++ b/src/niess/components/crystals.py
@@ -1,16 +1,16 @@
 # SPDX-FileCopyrightText: 2025-present Gregory Tucker <gregory.tucker@ess.eu>
 #
 # SPDX-License-Identifier: MIT
-from __future__ import annotations
-
-from dataclasses import dataclass
+from typing import ClassVar, Type
+from .component import Base
 from scipp import Variable
 
 
-@dataclass
-class IdealCrystal:
+class IdealCrystal(Base):
     position: Variable
     tau: Variable
+
+    __struct_field_types__: ClassVar[dict[str, Type]] = {'position': Variable, 'tau': Variable}
 
     def triangulate(self, unit=None):
         from scipp import sqrt, dot, vector, arange, concat, cross, isclose
@@ -106,11 +106,15 @@ class IdealCrystal:
         return rtp_x, rtp_y, rtp_angle
 
 
-@dataclass
 class Crystal(IdealCrystal):
     shape: Variable  # lengths: (in-scattering-plane perpendicular to Q, perpendicular to plane, along Q)
     orientation: Variable
     mosaic: Variable
+
+    __struct_field_types__: ClassVar[dict[str, Type]] = {
+        **{'shape': Variable, 'orientation': Variable, 'mosaic': Variable},
+        **IdealCrystal.__struct_field_types__
+    }
 
     def triangulate(self, unit=None):
         from ..spatial import vector_to_vector_quaternion

--- a/src/niess/components/detectors.py
+++ b/src/niess/components/detectors.py
@@ -1,12 +1,18 @@
-from dataclasses import dataclass
+from typing import ClassVar, Type
 from scipp import Variable
+from .component import Base
 
 
-@dataclass
-class Wire:
+class Wire(Base):
     at: Variable
     to: Variable
     resistivity: Variable
+
+    __struct_field_types__: ClassVar[dict[str, Type]] = {
+        'at': Variable,
+        'to': Variable,
+        'resistivity': Variable,
+    }
 
     def extreme_path_corners(self, horizontal: Variable, vertical: Variable, unit=None):
         from ..spatial import combine_extremes
@@ -76,9 +82,12 @@ class Wire:
         return (self.to - self.at) / 2
 
 
-@dataclass
 class DiscreteWire(Wire):
     elements: int
+
+    __struct_field_types__: ClassVar[dict[str, Type]] = {
+        'elements': int, **Wire.__struct_field_types__
+    }
 
     def __eq__(self, other):
         if not isinstance(other, DiscreteWire):
@@ -118,9 +127,12 @@ class DiscreteWire(Wire):
         return self.index_position(self.charge_index(a, b))
 
 
-@dataclass
 class DiscreteTube(DiscreteWire):
     radius: Variable
+
+    __struct_field_types__: ClassVar[dict[str, Type]] = {
+        'radius': Variable, **DiscreteWire.__struct_field_types__
+    }
 
     def __post_init__(self):
         from ..utilities import is_scalar, has_compatible_unit
@@ -180,10 +192,12 @@ class DiscreteTube(DiscreteWire):
         return isclose(self.radius, other.radius) and super().approx(other)
 
 
-
-@dataclass
 class He3Tube(DiscreteTube):
     pressure: Variable
+
+    __struct_field_types__: ClassVar[dict[str, Type]] = {
+        'pressure': Variable, **DiscreteTube.__struct_field_types__
+    }
 
     def __post_init__(self):
         from ..utilities import is_scalar, has_compatible_unit

--- a/src/niess/components/filter.py
+++ b/src/niess/components/filter.py
@@ -1,12 +1,10 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
 from scipp import Variable
 from .component import Component
 from mccode_antlr.assembler import Assembler
 
 
-@dataclass
 class Filter(Component):
     """A powder or amorphous material that effects a beam with physics from NCrystal
 
@@ -52,13 +50,11 @@ class Filter(Component):
         return 'NCrystal_sample', params
 
 
-@dataclass
 class OrderedFilter(Filter):
     """(likely) A Bragg scattering filter, e.g., Pyrolytic Graphite"""
     tau: Variable # the direction and lattice spacing used in the filter
 
 
-@dataclass
 class Attenuator(Filter):
     """A pneumatically insertable absorbing or scattering material
 

--- a/src/niess/components/guide.py
+++ b/src/niess/components/guide.py
@@ -1,22 +1,45 @@
-from __future__ import annotations
-
-from dataclasses import dataclass
-
+from typing import Union
 from mccode_antlr.assembler import Assembler
 from scipp import Variable
-from .component import Component
+from .component import Base, Component
 
 
-@dataclass
+def float_or_tuple_float(x):
+    if isinstance(x, float):
+        return x
+    if isinstance(x, list) and all(isinstance(i, float) for i in x):
+        return tuple(x)
+    if isinstance(x, tuple) and all(isinstance(i, float) for i in x):
+        return x
+    raise ValueError("Only float values (or a list-like collection of floats) allowed")
+
+
+def list_or_dict_to_type_list(typ, value):
+    ret = []
+    if isinstance(value, dict):
+        for name, cdict in value.items():
+            if not isinstance(cdict, dict):
+                raise ValueError("Only dicts should be provided here")
+            cdict['name'] = cdict.get('name', name)
+            ret.append(typ.from_calibration(cdict))
+    elif isinstance(value, list):
+        for v in value:
+            if not isinstance(v, dict):
+                raise ValueError("Only dicts should be provided here")
+            ret.append(typ.from_calibration(v))
+    else:
+        raise ValueError("Only dict or list of dicts should be provided here")
+    return ret
+
+
 class Guide(Component):
     length: Variable
-    left: float | tuple[float]  # m-value for x > 0 face
-    right: float | tuple[float] # m-value for x < 0 face
-    top: float | tuple[float]  # m-value for y > 0 face
-    bottom: float | tuple[float]   # m-value for the y < 0 face
+    left: Union[float, tuple[float]]  # m-value for x > 0 face
+    right: Union[float, tuple[float]] # m-value for x < 0 face
+    top: Union[float, tuple[float]]  # m-value for y > 0 face
+    bottom: Union[float, tuple[float]]   # m-value for the y < 0 face
 
 
-@dataclass
 class StraightGuide(Guide):
     width: Variable
     height: Variable
@@ -34,8 +57,8 @@ class StraightGuide(Guide):
         right = cal.get('right', m)
         top = cal.get('top', m)
         bottom = cal.get('bottom', m)
-        if any(isinstance(x, tuple) for x in (left, right, top, bottom)):
-            raise ValueError('StraightGuide does not support tuple m values')
+        if any(isinstance(x, (tuple, list)) for x in (left, right, top, bottom)):
+            raise ValueError('StraightGuide does not support multiple m values')
         width = cal['width']
         height = cal['height']
         return cls(name, position, orientation, length, left, right, top, bottom, width, height)
@@ -60,13 +83,12 @@ class StraightGuide(Guide):
         return 'Guide_gravity', p
 
 
-@dataclass
-class StraightGuides:
+class StraightGuides(Base):
     name: str
     segments: list[StraightGuide]
 
     @classmethod
-    def from_calibration(cls, cal: dict[str, dict | str]):
+    def from_calibration(cls, cal: dict):
         """Convert a dictionary of dictionaries to a list of StraightGuides
 
         This is likely called from Section.from_calibration, which would insert
@@ -75,12 +97,16 @@ class StraightGuides:
         """
         parent = cal.pop('name')
         segments = []
-        for name, cdict in cal.items():
-            if not isinstance(cdict, dict):
-                raise ValueError("Only dicts should be in this calibration dictionary")
-            if 'name' not in cdict:
-                cdict['name'] = name
-            segments.append(StraightGuide.from_calibration(cdict))
+        if 'segments' in cal and len(cal) == 1:
+            segments = list_or_dict_to_type_list(StraightGuide, cal['segments'])
+        else:
+            segments = list_or_dict_to_type_list(StraightGuide, cal)
+        # for name, cdict in cal.items():
+        #     if not isinstance(cdict, dict):
+        #         raise ValueError("Only dicts should be in this calibration dictionary")
+        #     if 'name' not in cdict:
+        #         cdict['name'] = name
+        #     segments.append(StraightGuide.from_calibration(cdict))
         return cls(parent, segments)
 
     def to_mccode(self, assembler: Assembler):
@@ -88,7 +114,6 @@ class StraightGuides:
             segment.to_mccode(assembler)
 
 
-@dataclass
 class TaperedGuide(Guide):
     in_width: Variable
     in_height: Variable
@@ -108,7 +133,7 @@ class TaperedGuide(Guide):
         right = cal.get('right', m)
         top = cal.get('top', m)
         bottom = cal.get('bottom', m)
-        if any(isinstance(x, tuple) for x in (left, right, top, bottom)):
+        if any(isinstance(x, (tuple, list)) for x in (left, right, top, bottom)):
             raise ValueError('StraightGuide does not support tuple m values')
         in_width = cal.get('in_width', cal.get('width'))
         out_width = cal.get('out_width', cal.get('width'))
@@ -137,15 +162,16 @@ class TaperedGuide(Guide):
         return 'Guide_gravity', p
 
 
-@dataclass
-class TaperedGuides:
+class TaperedGuides(Base):
     name: str
     segments: list[TaperedGuide]
 
     @classmethod
-    def from_calibration(cls, cal: dict[str, dict | str]):
+    def from_calibration(cls, cal: dict):
         parent = cal.pop('name')
         segments = []
+        if 'segments' in cal and len(cal) == 1:
+            cal = cal['segments']
         for name, cdict in cal.items():
             if 'name' not in cdict:
                 cdict['name'] = name
@@ -157,8 +183,7 @@ class TaperedGuides:
             segment.to_mccode(assembler)
 
 
-@dataclass
-class PartialEllipse:
+class PartialEllipse(Base):
     major: Variable
     minor: Variable
     offset: Variable
@@ -201,7 +226,6 @@ class PartialEllipse:
         return p
 
 
-@dataclass
 class EllipticGuide(Guide):
     horizontal: PartialEllipse
     vertical:  PartialEllipse
@@ -214,11 +238,11 @@ class EllipticGuide(Guide):
         position = cal.get('position', v([0, 0, 0.], unit='m'))
         orientation = cal.get('orientation', r(v([0, 0, 0.], unit='deg')))
         length = cal['length']
-        m = cal.get('m', 1.0)
-        left = cal.get('left', m)
-        right = cal.get('right', m)
-        top = cal.get('top', m)
-        bottom = cal.get('bottom', m)
+        m = float_or_tuple_float(cal.get('m', 1.0))
+        left = float_or_tuple_float(cal.get('left', m))
+        right = float_or_tuple_float(cal.get('right', m))
+        top = float_or_tuple_float(cal.get('top', m))
+        bottom = float_or_tuple_float(cal.get('bottom', m))
 
         ms = left, right, top, bottom
         if any(isinstance(x, tuple) for x in ms):

--- a/src/niess/components/moderator.py
+++ b/src/niess/components/moderator.py
@@ -1,9 +1,5 @@
-from dataclasses import dataclass
-from scipp import Variable
 from .component import Component
 
 
-
-@dataclass
 class Moderator(Component):
     pass

--- a/src/niess/components/monitors.py
+++ b/src/niess/components/monitors.py
@@ -1,5 +1,3 @@
-from dataclasses import dataclass
-
 from mccode_antlr.assembler import Assembler
 from scipp import Variable
 from .component import Component
@@ -41,8 +39,6 @@ def add_frame_monitor_metadata(inst, n):
     return inst
 
 
-
-@dataclass
 class FissionChamber(Component):
     """Zero-dimensional fission chamber monitor.
     Outputs events without any spatial information.
@@ -75,7 +71,7 @@ class FissionChamber(Component):
         # Build the NeXus Structure entry to point to the correct Kafka stream
         return add_frame_monitor_metadata(inst, self.__mccode__()[1]['nt'])
 
-@dataclass
+
 class He3Monitor(Component):
     """Zero-dimensional He3 tube monitor.
     Outputs events without any spatial information.
@@ -109,7 +105,6 @@ class He3Monitor(Component):
         return add_frame_monitor_metadata(inst, self.__mccode__()[1]['nt'])
 
 
-@dataclass
 class BeamCurrentMonitor(Component):
     """Zero-dimensional beam current monitor.
     Outputs a current sampled at a configurable frequency.
@@ -150,7 +145,6 @@ class BeamCurrentMonitor(Component):
         return add_frame_monitor_metadata(inst, self.__mccode__()[1]['nt'])
 
 
-@dataclass
 class GEM2D(Component):
     """Two-dimensional Gas Electron Multiplier monitor.
     Outputs events on X or Y strips (without coincidence) or at (X, Y) point

--- a/src/niess/components/section.py
+++ b/src/niess/components/section.py
@@ -1,4 +1,6 @@
-from dataclasses import dataclass, fields
+# from dataclasses import dataclass, fields
+import msgspec
+from typing import ClassVar, Type
 from ..utilities import calibration
 
 # TODO Consider whether it would be possible to use any one of:
@@ -7,8 +9,9 @@ from ..utilities import calibration
 #      dacite: https://github.com/konradhalas/dacite
 #      to handle (de)serializing these nested dataclass objects from calibration data.
 
-@dataclass
-class Section:
+# @dataclass
+class Section(msgspec.Struct, tag=True):
+    __struct_field_types__ = ClassVar[dict[str, Type]]
 
     @classmethod
     def parts(cls):
@@ -17,17 +20,17 @@ class Section:
         # dataclasses.fields(cls) trick stops working at some point
         # but the _order_ of the tuple returned by dataclasses.fields(Type) is
         # (currently) guaranteed to be the same as the order of definition above
-        return [field.name for field in fields(cls)]
+        return cls.__struct_fields__
 
     @classmethod
     def types(cls):
         """Get the ordered list of component types which make up this Section"""
-        return [field.type for field in fields(cls)]
+        return [cls.__struct_field_types__[field] for field in cls.__struct_fields__]
 
     @classmethod
     def items(cls):
         """Get the ordered list of component names and types which make up this Section"""
-        return [(field.name, field.type) for field in fields(cls)]
+        return [(field, cls.__struct_field_types__[field]) for field in cls.__struct_fields__]
 
     def to_mccode(self, *args, **kwargs):
         for part in self.parts():
@@ -44,5 +47,19 @@ class Section:
                 parameters[name]['name'] = name
             return parameters[name]
 
-        values = [T.from_calibration(named_par(n)) for n, T in cls.items()]
-        return cls(*values)
+        def to_type(name):
+            typ = cls.__struct_field_types__[name]
+            if isinstance(parameters[name], typ):
+                return parameters[name]
+            return typ.from_calibration(named_par(name))
+
+        return cls(*[to_type(n) for n in cls.parts()])
+
+    def to_dict(self):
+        return {f: getattr(self, f) for f in self.__struct_fields__}
+
+    @classmethod
+    def from_dict(cls, d):
+        # TODO make a function to recurse through a dictionary and ensure
+        #      scipp.Variable and mccode_antlr.? are converted
+        return cls.from_calibration(d)

--- a/src/niess/components/source.py
+++ b/src/niess/components/source.py
@@ -1,6 +1,5 @@
-from __future__ import annotations
+from typing import Optional, Union
 
-from dataclasses import dataclass
 from scipp import Variable
 
 from mccode_antlr.common.parameters import InstrumentParameter
@@ -11,12 +10,10 @@ ESS_SOURCE_DURATION = Variable(values=2.857e-3, unit='s', dims=None)
 
 
 
-@dataclass
 class Source(Component):
     pass
 
 
-@dataclass
 class ESSource(Source):
     """Representation of the ESS Butterfly source
 
@@ -26,21 +23,22 @@ class ESSource(Source):
     beamline: int
     height: Variable
     cold_frac: float
-    focus_distance: Variable | None
-    focus_width: Variable | None
-    focus_height: Variable | None
+    focus_distance: Optional[Variable]
+    focus_width: Optional[Variable]
+    focus_height: Optional[Variable]
     cold_performance: float
     thermal_performance: float
-    wavelength_minimum: Variable | InstrumentParameter | None
-    wavelength_maximum: Variable | InstrumentParameter | None
-    latest_emission_time: Variable | None
-    n_pulses: int | None
-    accelerator_power: Variable | None
+    wavelength_minimum: Optional[Union[Variable, InstrumentParameter]]
+    wavelength_maximum: Optional[Union[Variable, InstrumentParameter]]
+    latest_emission_time: Optional[Variable]
+    n_pulses: Optional[int]
+    accelerator_power: Optional[Variable]
 
     @classmethod
     def from_calibration(cls, cal: dict):
         from scipp import vector as v, scalar as s
         from scipp.spatial import rotations_from_rotvecs as r
+        from niess.io.mccode import reconstitute_instrument_parameter as rip
         name = cal.get('name', 'ESS_source')
         position = cal.get('position', v([0, 0, 0.], unit='m'))
         orientation = cal.get('orientation', r(v([0, 0, 0.], unit='rad')))
@@ -54,12 +52,8 @@ class ESSource(Source):
         focus_height = cal.get('focus_height', None)
         cold_performance = cal.get('cold_performance', 1.0)
         thermal_performance = cal.get('thermal_performance', 1.0)
-        wavelength_minimum = cal.get('wavelength_minimum', None)
-        wavelength_maximum = cal.get('wavelength_maximum', None)
-        if isinstance(wavelength_minimum, str):
-            wavelength_minimum = InstrumentParameter.parse(wavelength_minimum)
-        if isinstance(wavelength_maximum, str):
-            wavelength_maximum = InstrumentParameter.parse(wavelength_maximum)
+        wavelength_minimum = rip(cal.get('wavelength_minimum', None), (Variable,))
+        wavelength_maximum = rip(cal.get('wavelength_maximum', None), (Variable,))
         latest_emission_time = cal.get('latest_emission_time', None)
         n_pulses = cal.get('n_pulses', None)
         accelerator_power = cal.get('accelerator_power', None)
@@ -97,10 +91,9 @@ class ESSource(Source):
         return 'ESS_butterfly', pars
 
     def to_mccode(self, assembler):
-        from dataclasses import fields
         from ..mccode import ensure_runtime_parameter
-        for field in fields(self):
-            p = getattr(self, field.name)
+        for field in self.fields():
+            p = getattr(self, field)
             if isinstance(p, InstrumentParameter):
                 ensure_runtime_parameter(assembler, p)
         return super().to_mccode(assembler)

--- a/src/niess/io/json.py
+++ b/src/niess/io/json.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+from pathlib import Path
+import msgspec
+from niess.io.utils import encode_hook, decode_hook, Model, from_model
+
+
+def to_json(obj) -> bytes:
+    enc_hook = encode_hook(msgspec.json.Encoder())
+    encoder = msgspec.json.Encoder(enc_hook=enc_hook)
+    return encoder.encode(Model.from_value(obj, encoder=encoder))
+
+
+def from_json(msg: bytes):
+    from niess.io.utils import MODEL_DECODE
+    decoded = msgspec.json.decode(msg, type=Model)
+
+    dec_hook = decode_hook(msgspec.json.Decoder())
+    ## FIXME The first (typed) version causes the TypeError
+    ##       "unsupported operand type(s) for |: 'classmethod' and 'classmethod'"
+    ##       _probably_ due to mccode_antlr.common.Expr using Union[...]
+    ##       _without_ specifying to msgspec that its Structs should store type
+    ##       information.
+    # if decoded.name in MODEL_DECODE:
+    #     decoder = msgspec.json.Decoder(MODEL_DECODE[decoded.name], dec_hook=dec_hook)
+    # else:
+    #     decoder = msgspec.json.Decoder(dec_hook=dec_hook)
+    decoder = msgspec.json.Decoder(dec_hook=dec_hook)
+    return from_model(decoder, decoded)
+
+
+def save_json(obj, filename: str | Path) -> None:
+    with open(filename, "wb") as f:
+        f.write(to_json(obj))
+
+
+def load_json(filename: str | Path):
+    with open(filename, "rb") as f:
+        return from_json(f.read())

--- a/src/niess/io/markdown.py
+++ b/src/niess/io/markdown.py
@@ -1,0 +1,145 @@
+import msgspec
+from typing import Callable
+
+class MarkdownRow(msgspec.Struct):
+    contents: tuple[list[str], ...]
+    lengths: tuple[int, ...]
+    is_heading: bool = False
+
+    def row_lengths(self):
+        def max_or_zero(col):
+            if col is None or len(col) == 0:
+                return 0
+            return max(len(c) for c in col)
+
+        return [max_or_zero(col) for col in self.contents]
+
+    def __post_init__(self):
+        def correct(content):
+            if isinstance(content, str):
+                return content.split('\n')
+            return content
+        self.contents = tuple(correct(c) for c in self.contents)
+        self.lengths = tuple(self.row_lengths())
+
+    @classmethod
+    def from_json(cls, data, headings: list[str], transforms: dict[str,Callable]):
+        if isinstance(data, (str, bytes)):
+            from json import loads
+            data = loads(data)
+        contents = [transforms[heading](data[heading]) for heading in headings]
+        lengths = [0 for _ in headings]
+        return cls(tuple(contents), tuple(lengths))
+
+    def __str__(self):
+        rep = ''
+        height = 1 + max(len(content) for content in self.contents)
+        # Top line (if heading)
+        if self.is_heading:
+            for length in self.lengths:
+                rep += '+' + '-' * (length + 2)
+            rep += '+\n'
+        # Contents line(s)
+        for line in range(height):
+            for col, length in zip(self.contents, self.lengths):
+                if len(col) > line:
+                    rep += f'| {col[line]:{length}} '
+                else:
+                    rep += '|' + ' ' * (length + 2)
+            rep += '|\n'
+        # Bottom line
+        for length in self.lengths:
+            rep += '+' + ('=' if self.is_heading else '-') * (length + 2)
+        rep += '+\n'
+        return rep
+
+class MarkdownTable(msgspec.Struct):
+    title: str
+    rows: list[MarkdownRow]
+
+    def __post_init__(self):
+        self.rows[0].is_heading = True
+        lengths = self.rows[0].lengths
+        for row in self.rows[1:]:
+            lengths = [max(a, b) for a, b in zip(lengths, row.lengths)]
+        for row in self.rows:
+            row.lengths = tuple(lengths)
+
+    def __str__(self):
+        return ''.join(str(row) for row in self.rows)
+
+
+def to_str(value):
+    if hasattr(value, '__len__') and isinstance(value[0], float):
+        return '(' + ','.join(f'{x:0.3f}' for x in value) + ')'
+    return str(value)
+
+def scipp_variable_transform(x):
+    if not isinstance(x, dict) or 'obj' not in x:
+        raise ValueError(f'{x} is not a scipp variable?')
+    o = x['obj']
+    value = o.get('value', o.get('values', None))
+    unit = o.get('unit')
+    dims = o.get('dims')
+    ret = to_str(value)
+    if unit is not None and unit != 'dimensionless':
+        ret += f' {unit}'
+    if dims is not None:
+        ret += f' {dims}'
+    return ret
+
+
+def parameter_one(d, depth):
+    if isinstance(d, dict) and 'name' in d and 'scipp.Variable' == d['name']:
+        return scipp_variable_transform(d)
+    elif isinstance(d, dict):
+        return '\n' + '\n'.join(parameter_dict(d, depth+1))
+    return str(d)
+
+
+def parameter_dict(d, depth=0):
+    return ['  '*depth + f'- {k} = {parameter_one(v, depth)}' for k, v in d.items()]
+
+
+def parameters_transform(parameters):
+    return '\n'.join(parameter_dict(parameters))
+
+
+def to_markdown(obj):
+    from json import loads
+    from .json import to_json
+    data = loads(to_json(obj))
+
+    if not 'name' in data or not 'obj' in data:
+        raise TypeError('Missing "name" and "obj" fields')
+
+    title = data['name']
+    data = data['obj']
+
+    # Data is now an (ordered) dictionary, with keys equal to component names
+    headings = ['name', 'position', 'orientation', 'parameters']
+    transformations = {
+        'name': lambda x: f'`{x}`',
+        'position': scipp_variable_transform,
+        'orientation': scipp_variable_transform,
+        'parameters': parameters_transform,
+    }
+
+    def one_entry(entry):
+        name, pos, ori = entry.pop('name'), entry.pop('position'), entry.pop('orientation')
+        entry = dict(name=name, position=pos, orientation=ori, parameters=entry)
+        return MarkdownRow.from_json(entry, headings, transformations)
+
+    def one_component(component):
+        ret = []
+        if 'segments' in component:
+            for segment in component['segments']:
+                ret.append(one_entry(segment))
+        else:
+            ret.append(one_entry(component))
+        return ret
+
+    rows = [r for value in data.values() for r in one_component(value)]
+    row0 = MarkdownRow(headings, headings)
+    table = MarkdownTable(title, [row0] + rows)
+    return table

--- a/src/niess/io/mccode.py
+++ b/src/niess/io/mccode.py
@@ -1,0 +1,32 @@
+from typing import Any, Type
+import msgspec
+
+from mccode_antlr.io.utils import MODEL_ENC
+
+MCCODE_MODEL_ENCODE = {k: f'mccode.{v}' for k, v in MODEL_ENC.items()}
+MCCODE_MODEL_DECODE = {v: k for k, v in MCCODE_MODEL_ENCODE.items()}
+
+
+class McCodeModel(msgspec.Struct):
+    name: str
+    obj: msgspec.Raw
+
+    @classmethod
+    def from_value(cls, obj: Any, encoder=None):
+        if encoder is None:
+            raise ValueError("And encoder must be provided")
+        model_type = MCCODE_MODEL_ENCODE[type(obj)]
+        if model_type in MCCODE_MODEL_DECODE and hasattr(obj, 'to_dict'):
+            obj = obj.to_dict()
+        return cls(model_type, msgspec.Raw(encoder.encode(obj)))
+
+
+def reconstitute_instrument_parameter(a: Any, others: tuple[Type,...]):
+    from mccode_antlr.common import InstrumentParameter
+    if a is None or isinstance(a, InstrumentParameter) or any(isinstance(a, x) for x in others):
+        return a
+    if isinstance(a, str):
+        return InstrumentParameter.parse(a)
+    if isinstance(a, dict):
+        return InstrumentParameter.from_dict(a)
+    raise ValueError(f"Unknown relationship of type {type(a)} to InstrumentParameter")

--- a/src/niess/io/scipp.py
+++ b/src/niess/io/scipp.py
@@ -1,0 +1,101 @@
+from typing import Any, Type
+import msgspec
+from scipp import Variable, DType
+
+
+SCIPP_MODEL_ENCODE = {
+    Variable: 'scipp.Variable'
+}
+SCIPP_MODEL_DECODE = {v: k for k, v in SCIPP_MODEL_ENCODE.items()}
+
+def variable_to_dict(v: Variable) -> dict[str, Any]:
+    d = {'unit': str(v.unit), 'dtype': str(v.dtype)}
+    def tolist(x):
+        if d['dtype'] == 'string' and v.size == 1:
+            return x
+        if hasattr(x, 'tolist'):
+            return x.tolist()
+        return x
+
+    if v.size == 1:
+        d['value'] = tolist(v.value)
+        if v.variance is not None:
+            d['variance'] = tolist(v.variance)
+    else:
+        d['values'] = tolist(v.values)
+        d['dims'] = list(v.dims)
+        if v.variances is not None:
+            d['variances'] = tolist(v.variances)
+    return d
+
+def variable_json_schema():
+    schema = {
+        "$defs": {
+            "nd_array": {
+                "type": "array",
+                "items": {"type": ["string", "integer", "number", {"$ref": "#/$defs/nd_array"}]},
+                "minItems": 1
+            }
+        },
+        'type': 'object',
+        "title": "Scipp Variable",
+        "description": "A scalar or array variable in scipp",
+        "properties": {
+            'unit': {"type": "string"},
+            'dtype': {"type": "string"},
+            "value": {"type": "number"},
+            "variance": {"type": "number"},
+            "values": {"type": {"$ref": "#/$defs/nd_array"}},
+            "variances": {"type": {"$ref": "#/$defs/nd_array"}},
+            "dims": {"type": "array", "items": {"type": "string"}},
+        },
+        "required": ["unit", "dtype", {"oneOf": ["value", "values"]}]
+    }
+    return schema
+
+
+def dict_to_variable(d: dict) -> Variable:
+    from scipp import array, scalar
+    if isinstance(dtype := d['dtype'], str) and hasattr(DType, dtype):
+        d['dtype'] = getattr(DType, dtype)
+    if 'values' in d:
+        return array(**d)
+    else:
+        return scalar(**d)
+
+
+SCIPP_TO_DICT = {
+    Variable: variable_to_dict,
+}
+DICT_TO_SCIPP = {
+    'scipp.Variable': dict_to_variable,
+}
+
+SCIPP_JSON_SCHEMA = {Variable: variable_json_schema}
+
+
+class ScippModel(msgspec.Struct):
+    name: str
+    obj: msgspec.Raw
+
+    @classmethod
+    def from_value(cls, obj: Any, encoder=None):
+        if encoder is None:
+            raise ValueError("An encoder must be provided")
+        model_type = SCIPP_MODEL_ENCODE[type(obj)]
+        if 'scipp.Variable' == model_type:
+            obj = variable_to_dict(obj)
+        return cls(model_type, msgspec.Raw(encoder.encode(obj)))
+
+
+def to_scipp_model(scipp_model_encoder, obj):
+    return ScippModel(scipp_model_encoder, obj)
+
+
+def from_scipp_model(scipp_model_decoder, msg: ScippModel):
+    if msg.name in SCIPP_MODEL_DECODE:
+        return decode_scipp_model(scipp_model_decoder.decode(msg.obj))
+    raise TypeError(f"{msg.name} is not a valid scipp model")
+
+def decode_scipp_model(data: dict):
+    return dict_to_variable(data)

--- a/src/niess/io/utils.py
+++ b/src/niess/io/utils.py
@@ -1,0 +1,198 @@
+from typing import Any, Type
+import msgspec
+import numpy as np
+
+from niess.bifrost import Tank as BIFROSTTank, Primary as BIFROSTPrimary
+
+from niess.components import (
+    DirectSecondary,
+    IndirectSecondary,
+    IdealCrystal,
+    Crystal,
+    Wire,
+    DiscreteWire,
+    DiscreteTube,
+    He3Tube,
+    Aperture,
+    Jaw,
+    Slit,
+    Chopper,
+    DiscChopper,
+    FermiChopper,
+    Collimator,
+    SollerCollimator,
+    RadialCollimator,
+    Component,
+    Attenuator,
+    Filter,
+    OrderedFilter,
+    Guide,
+    EllipticGuide,
+    TaperedGuide,
+    StraightGuide,
+    StraightGuides,
+    TaperedGuides,
+    Moderator,
+    FissionChamber,
+    He3Monitor,
+    BeamCurrentMonitor,
+    GEM2D,
+    ESSource,
+    Section,
+)
+
+from .scipp import (
+    SCIPP_MODEL_DECODE, SCIPP_MODEL_ENCODE, ScippModel, from_scipp_model,
+    SCIPP_TO_DICT, DICT_TO_SCIPP
+)
+from .mccode import (
+    MCCODE_MODEL_ENCODE, MCCODE_MODEL_DECODE, McCodeModel
+)
+
+MODEL_ENCODE = {
+    BIFROSTTank: 'BIFROST Tank',
+    BIFROSTPrimary: 'BIFROST Primary',
+    DirectSecondary: 'DirectSecondary',
+    IndirectSecondary: 'IndirectSecondary',
+    IdealCrystal: 'IdealCrystal',
+    Crystal: 'Crystal',
+    Wire: 'Wire',
+    DiscreteWire: 'DiscreteWire',
+    DiscreteTube: 'DiscreteTube',
+    He3Tube: 'He3Tube',
+    Aperture: 'Aperture',
+    Jaw: 'Jaw',
+    Slit: 'Slit',
+    Chopper: 'Chopper',
+    DiscChopper: 'DiscChopper',
+    FermiChopper: 'FermiChopper',
+    Collimator: 'Collimator',
+    SollerCollimator: 'SollerCollimator',
+    RadialCollimator: 'RadialCollimator',
+    Component: 'Component',
+    Attenuator: 'Attenuator',
+    Filter: 'Filter',
+    OrderedFilter: 'OrderedFilter',
+    Guide: 'Guide',
+    EllipticGuide: 'EllipticGuide',
+    TaperedGuide: 'TaperedGuide',
+    StraightGuide: 'StraightGuide',
+    StraightGuides: 'StraightGuides',
+    TaperedGuides: 'TaperedGuides',
+    Moderator: 'Moderator',
+    FissionChamber: 'FissionChamber',
+    He3Monitor: 'He3Monitor',
+    BeamCurrentMonitor: 'BeamCurrentMonitor',
+    GEM2D: 'GEM2D',
+    ESSource: 'ESSource',
+    Section: 'Section',
+}
+MODEL_DECODE = {v: k for k, v in MODEL_ENCODE.items()}
+
+
+class Model(msgspec.Struct):
+    name: str
+    obj: msgspec.Raw
+
+    @classmethod
+    def from_value(cls, obj: Any, encoder=None):
+        if encoder is None:
+            raise ValueError("An encoder must be provided")
+        obj_type = type(obj)
+        if obj_type in SCIPP_TO_DICT:
+            model_type = SCIPP_MODEL_ENCODE[obj_type]
+            obj = SCIPP_TO_DICT[obj_type](obj)
+        elif obj_type in MCCODE_MODEL_ENCODE:
+            model_type = MCCODE_MODEL_ENCODE[obj_type]
+            if hasattr(obj, 'to_dict'):
+                obj = obj.to_dict()
+        else:
+            model_type = MODEL_ENCODE[obj_type]
+            if hasattr(obj, 'to_dict'):
+                obj = obj.to_dict()
+        return cls(model_type, msgspec.Raw(encoder.encode(obj)))
+
+
+def to_model(model_encoder, obj):
+    return Model(model_encoder, obj)
+
+
+def traverse_decoded(a):
+    if isinstance(a, dict):
+        return traverse_decoded_dict(a)
+    return traverse_decoded_one(a)
+
+
+def traverse_decoded_dict(d: dict):
+    """Convert special dicts based on specified conversion routines or
+    traverse through the provided standard dict"""
+    if 'name' in d and 'obj' in d and len(d) == 2:
+        # one of the models:
+        if d['name'] in DICT_TO_SCIPP:
+            return DICT_TO_SCIPP[d['name']](d['obj'])
+        print(f"{d['name']} should be handled")
+    # if 'name' in d and 'obj' in d and d['name'] in DICT_TO_MCCODE:
+    #     return DICT_TO_MCCODE[d['name']](d['obj'])
+    for k, v in d.items():
+        d[k] = traverse_decoded(v)
+    return d
+
+
+def traverse_decoded_one(a):
+    if isinstance(a, dict):
+        return traverse_decoded_dict(a)
+    elif isinstance(a, list):
+        return [traverse_decoded(x) for x in a]
+    elif isinstance(a, tuple):
+        return tuple(traverse_decoded(x) for x in a)
+    return a
+
+
+def from_model(model_decoder, model):
+    if model.name in MODEL_DECODE:
+        data = model_decoder.decode(model.obj)
+        if isinstance(data, dict):
+            data = traverse_decoded_dict(data)
+            return MODEL_DECODE[model.name].from_dict(data)
+        return data
+    elif model.name in SCIPP_MODEL_DECODE:
+        data = model_decoder.decode(model.obj)
+        if isinstance(data, dict):
+            return DICT_TO_SCIPP[model.name](data)
+        return data
+    elif model.name in MCCODE_MODEL_DECODE:
+        data = model_decoder.decode(model.obj)
+        if isinstance(data, dict):
+            return MCCODE_MODEL_DECODE[model.name].from_dict(data)
+        return data
+    raise ValueError(f"Model {model.name} is not supported")
+
+
+def encode_hook(encoder):
+    def hook(obj):
+        if isinstance(obj, np.integer):
+            return int(obj)
+        elif isinstance(obj, np.floating):
+            return float(obj)
+        elif type(obj) in SCIPP_MODEL_ENCODE:
+            return ScippModel.from_value(obj, encoder)
+        raise TypeError(f"Object of type {type(obj)} is not supported")
+    return hook
+
+
+def decode_hook(scipp_model_decoder):
+    def hook(typ: Type, obj: Any):
+        if typ is ScippModel:
+            return from_scipp_model(scipp_model_decoder, obj)
+        # A data type that's been encoded as a ScippModel doesn't know it?
+        if typ in SCIPP_MODEL_ENCODE and isinstance(obj, dict) and 'obj' in obj:
+            return DICT_TO_SCIPP[SCIPP_MODEL_ENCODE[typ]](obj['obj'])
+        raise TypeError(f"Object of type {type(obj)} is not supported")
+    return hook
+
+
+def schema_hook(typ):
+    from .scipp import SCIPP_JSON_SCHEMA
+    if typ in SCIPP_JSON_SCHEMA:
+        return SCIPP_JSON_SCHEMA[typ]()
+    raise TypeError(f"Object of type {typ} is not supported")

--- a/tests/test_bifrost_primary.py
+++ b/tests/test_bifrost_primary.py
@@ -185,26 +185,29 @@ def test_primary_create():
 
 
 def test_primary_serialize_deserialize():
-    from json import dumps, loads
+    from niess.io.json import to_json, from_json
     from niess.bifrost.parameters import primary_parameters
     from niess.bifrost.primary import Primary
-    from niess.utilities import serializable
-    from dataclasses import asdict
-    from niess.utilities import compare
     parameters = primary_parameters()
     primary = Primary.from_calibration(parameters)
-    pdict = serializable(asdict(primary))
-    ddict = loads(dumps(pdict, indent=4))
-    assert compare(pdict, ddict)
+    returned = from_json(to_json(primary))
+    assert primary == returned
 
 
 def test_primary_without_parameters():
     from niess.bifrost.primary import Primary
     from niess.bifrost.parameters import primary_parameters
-    from niess.utilities import serializable
-    from dataclasses import asdict
     p0 = Primary.from_calibration()
     pp = Primary.from_calibration(primary_parameters())
-    d0 = serializable(asdict(p0))
-    dp = serializable(asdict(pp))
-    assert d0 == dp
+    assert p0 == pp
+
+
+def test_instrument_to_json():
+    from pathlib import Path
+    from niess.io.json import save_json
+    from niess.bifrost.parameters import primary_parameters, tank_parameters
+    from niess.bifrost.primary import Primary
+    from niess.bifrost.tank import Tank
+    root = Path(__file__).parent
+    save_json(Primary.from_calibration(primary_parameters()), root / 'primary.json')
+    save_json(Tank.from_calibration(tank_parameters()), root / 'tank.json')

--- a/tests/test_json_io.py
+++ b/tests/test_json_io.py
@@ -1,0 +1,126 @@
+import scipp as sc
+
+
+def scipp_round_trip(variable):
+    import msgspec
+    from niess.io.scipp import ScippModel, from_scipp_model
+    encoder = msgspec.json.Encoder()
+    modeled = ScippModel.from_value(variable, encoder=encoder)
+    json = encoder.encode(modeled)
+
+    decoded = msgspec.json.decode(json, type=ScippModel)
+    assert modeled == decoded
+    return from_scipp_model(msgspec.json.Decoder(), decoded)
+
+
+def niess_round_trip(value):
+    import msgspec
+    from niess.io.utils import Model, from_model, decode_hook, MODEL_DECODE
+    from niess.io.utils import encode_hook
+    encoder = msgspec.json.Encoder(enc_hook=encode_hook(msgspec.json.Encoder()))
+    modeled = Model.from_value(value, encoder=encoder)
+    json = encoder.encode(modeled)
+    decoded = msgspec.json.decode(json, type=Model)
+    assert modeled == decoded
+    dec_hook = decode_hook(msgspec.json.Decoder())
+    decoder = msgspec.json.Decoder(dec_hook=dec_hook)
+    return from_model(decoder, decoded)
+
+
+def test_scipp_scalar():
+    p = sc.scalar(3.14159, unit='rad')
+    assert p == scipp_round_trip(p)
+
+def test_scipp_vector():
+    p = sc.vector([1,2,3.], unit='m')
+    assert p == scipp_round_trip(p)
+
+
+def test_scipp_rotation():
+    q = sc.spatial.rotation(value=[0,0,0,1.])
+    assert q == scipp_round_trip(q)
+
+
+def test_scipp_array():
+    from numpy.random import random
+    a = sc.array(values=random((10,20)), variances=random((10,20)), dims=['a', 'b'], unit='m')
+    res = scipp_round_trip(a)
+    assert sc.allclose(res, a)
+
+
+def test_mccode_types():
+    from mccode_antlr.common.parameters import InstrumentParameter
+    par = InstrumentParameter.parse('int named/"K" = -1')
+    print(par)
+    assert par.name == 'named'
+    assert par.unit == '"K"'
+    assert par.value.value == -1
+    ret = niess_round_trip(par)
+    assert par == ret
+
+
+def test_fake_niess_component():
+    from niess.components import He3Monitor
+    from pytest import raises
+    from msgspec import ValidationError
+    b = He3Monitor(
+        name='mon1',
+        position=[1,2,3],
+        orientation=[0,0,0,1],
+        radius=10,
+        length=20,
+        pressure=1
+    )
+    # If the decoder used the typed variant, this would fail ... but other
+    # types wouldn't decode since they include McCode_antlr objects ...
+    # # Fails due to the incorrect data types provided
+    # with raises(ValidationError):
+    #     niess_round_trip(b)
+    assert b == niess_round_trip(b)
+
+
+def test_niess_component():
+    from niess.components import He3Monitor
+    import scipp as sc
+    b = He3Monitor(
+        name='mon2',
+        position=sc.vector([1, 2, 3], unit='m'),
+        orientation=sc.spatial.rotation(value=[0, 0, 0, 1]),
+        radius=sc.scalar(10., unit='mm'),
+        length=sc.scalar(20, unit='mm'),
+        pressure=sc.scalar('1', unit='atm')
+    )
+    assert b == niess_round_trip(b)
+
+
+def test_niess_source():
+    from niess.components import ESSource
+    source = ESSource.from_calibration(
+        dict(wavelength_minimum='double minimum/"angstrom"=1.0',)
+    )
+    assert source == niess_round_trip(source)
+
+
+def test_section():
+    from niess.components import Section
+    section = Section()
+    returned = niess_round_trip(section)
+    assert section == returned
+
+
+def test_bifrost_primary():
+    from niess.bifrost.parameters import primary_parameters
+    from niess.bifrost import Primary
+    primary = Primary.from_calibration(primary_parameters())
+    assert primary == primary
+    returned = niess_round_trip(primary)
+    assert primary == returned
+
+
+def test_bifrost_tank():
+    from niess.bifrost.parameters import tank_parameters
+    from niess.bifrost import Tank
+    tank = Tank.from_calibration(tank_parameters())
+    assert tank == tank
+    returned = niess_round_trip(tank)
+    assert tank == returned


### PR DESCRIPTION
Switching to `msgspec.Struct` based objects makes serializing _to_, e.g., JSON trivial but deserializing the nested objects requires bit of a hack, the form of the `__struct_field_types__` dictionary per class to replicate `dataclasses`' `fields` method's ability to return expected _types_ for each of the string values stored in `__struct_fields__` by `msgspec`.
This requires defining the name and type of each class member twice, which is less than optimal.

Serialization to and from JSON works. The output to  Markdown table is passable, but needs polish.