### PR TITLE
[Update] version to reflect refactor

### DIFF
--- a/src/niess/__about__.py
+++ b/src/niess/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2025-present Gregory Tucker <gregory.tucker@ess.eu>
 #
 # SPDX-License-Identifier: MIT
-__version__ = "0.0.7"
+__version__ = "0.1.0"


### PR DESCRIPTION
Now using `msgspec.Struct` instead of `dataclass` decorators.