### PR TITLE
[Fix] attenuator WHEN statement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,8 @@ dependencies = [
   "scipy",
   "mccode-antlr>=0.15.2",
   "mccode-to-kafka>=0.2.2",
-  "msgspec>=0.19.0"
+  "msgspec>=0.19.0",
+  "ncrystal>=4.2.4" # required for B4C_sg166_BoronCarbide
 ]
 
 [project.urls]

--- a/src/niess/bifrost/guide_straight.py
+++ b/src/niess/bifrost/guide_straight.py
@@ -189,7 +189,7 @@ def straight_guide_parameters(guide_pos, guide_rot, chopper_height) -> tuple[dic
     }
 
     plexiglass = 'AcrylicGlass_C5O2H8'
-    b4c = 'B4C_sg166_BoronCarbide'
+    b4c = 'B4C_sg166_BoronCarbide' # TODO check whether this should be *enriched* 10B, https://github.com/mctools/ncrystal/discussions/286
     attenuator = {'width': 88 * mm, 'height': 105 * mm, 'composition': plexiglass}
 
     devices = (

--- a/src/niess/components/filter.py
+++ b/src/niess/components/filter.py
@@ -66,11 +66,12 @@ class Attenuator(Filter):
     | Polycarbonate                                    | 'Polycarbonate_C16O3H14' |
     """
     def to_mccode(self, assembler: Assembler):
-        from mccode_antlr.common import InstrumentParameter
+        from mccode_antlr.common import InstrumentParameter, Expr, Value, DataType, ObjectType, ShapeType
         parameter = InstrumentParameter.parse(f"int {self.name}_in = 0")
         assembler.instrument.add_parameter(parameter, ignore_repeated=True)
         comp = super().to_mccode(assembler)
-        comp.WHEN(parameter.name)
+        var = Value(parameter.name, DataType.int, ObjectType.parameter, ShapeType.scalar)
+        comp.WHEN(Expr(var))
         return comp
 
 


### PR DESCRIPTION
The `WHEN` statement needs to be an `Expr`, which is itself a `Value` with information that it represents an instrument parameter.

The B4C mask material was added in NCrystal 4.2.4, and also can have its isotopic composition listed if it is not natural abundance.