### PR TITLE
Issues 21 23

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
   "scipp>=25.11.0",
   "numpy",
   "scipy",
-  "mccode-antlr>=0.15.2",
+  "mccode-antlr>=0.16.1",
   "mccode-to-kafka>=0.2.2",
   "msgspec>=0.20.0",
   "networkx>=3.6",

--- a/src/niess/bifrost/guide_curved.py
+++ b/src/niess/bifrost/guide_curved.py
@@ -99,6 +99,7 @@ def curved_guide_partial_dict(ref_p, ref_r, radius, table, lengths, min_unit, ma
             if Type.guide == entry[0]:
                 ttype, number, identifier, name, length = entry
                 fname = f'unit_{section}_{name}'
+                # lengths is a integer-keyed dictionary, we pick the right one
                 d[fname], ref_p, ref_r = curved_guide_unit_dictionary(
                     ref_p,
                     radius_of_curvature_to_rotation(lengths[section][0], radius) * ref_r,
@@ -203,7 +204,7 @@ def curved_guide_parameters(guide_start_vec, guide_start_rot, bunker_chopper_hei
         6: [500.0 * mm, 500.0 * mm, 500.0 * mm, 140 * mm],
         7: [118.3 * mm, 500.0 * mm, 500.0 * mm, 500.0 * mm],
         8: [500.0 * mm, 500.0 * mm, 118.3 * mm, 500.0 * mm],
-        9: [500.0 * mm, 500.0 * mm, 500.0 * mm],
+        9: [500.0 * mm, 500.0 * mm, 68.3 * mm, 500.0 * mm],
         10: [175.71 * mm, 351.42 * mm, 351.42 * mm, 175.71 * mm], # Cu substrate
         11: [236.32 * mm, 472.63 * mm, 236.32 * mm], # Cu substrate
         12: [500.0 * mm, 500.0 * mm, 448.22 * mm],

--- a/src/niess/bifrost/parameters.py
+++ b/src/niess/bifrost/parameters.py
@@ -76,8 +76,9 @@ def tube_xz_displacement_to_quaternion(length: Variable, displacement: Variable)
     return quaternion
 
 
-def primary_parameters():
+def primary_parameters(use_tcs=False):
     from scipp import array, vector, scalar, norm
+    from scipp.spatial import rotations_from_rotvecs as r
     from ..spatial import mccode_quaternion, at_relative_dict, at_relative
     from .guide_compressor import primary_compressor_parameters
     from .guide_curved import curved_guide_parameters
@@ -91,8 +92,29 @@ def primary_parameters():
     z = vector([0, 0, 1.0])
 
     eps = 1.0e-5
+    # The guide is defined in the 'w4' coordinate system
     guide_zero = vector([0.01277, 0, 1.903398 - eps], unit='m')
     guide_zero_rot = mccode_quaternion(0, -0.56, 0)
+
+    if use_tcs:
+        # Relative to the Target Coordinate System (TCS),
+        # The BIFROST Instrument Specific Coordinate System (ISCS) is at:
+        tcs_iscs_position = vector([-77.05, 67.72, 137], unit='mm').to(unit='m')
+        tcs_iscs_orientation = r(vector([0, 132.14, 0], unit='deg'))
+        # But the McStas ESS_butterfly component 'sector': 'W', 'beamline': 4
+        # defines its own coordinate system, which is rotated relative to both
+        # The ISCS position _in_ the McStas 'W4' coordinates:
+        w4_iscs_position = vector([31.38,0,-0.01], unit='mm')
+        # In thE TCS coordinate system, W4 focal point is at and oriented:
+        w4_orientation = r(vector([0., 132.7, 0.],  unit='deg'))
+        w4_position = vector([89, 137., -54], unit='mm').to(unit='m')
+        # but we want to move everything to TCS:
+        moderator_offset =vector([0, 137., 0], unit='mm').to(unit='m')
+        guide_zero_rot = w4_orientation * guide_zero_rot
+        guide_zero = at_relative(w4_position, w4_orientation, guide_zero)
+    else:
+        w4_position = vector([0, 0, 0.], unit='m')
+        w4_orientation = r(vector([0, 0, 0.], unit='deg'))
 
     p['source'] = {
         'sector': 'W',
@@ -102,6 +124,8 @@ def primary_parameters():
         'focus_distance': norm(guide_zero),
         'focus_width': (0.068797 + 2 * 0.01277) * m,  # including the substrate?
         'focus_height': 0.03472 * m,
+        'position': w4_position,
+        'orientation': w4_orientation,
     }
 
     p.update(primary_compressor_parameters(guide_zero, guide_zero_rot))

--- a/src/niess/bifrost/tank.py
+++ b/src/niess/bifrost/tank.py
@@ -162,7 +162,7 @@ class Tank(Base):
 
         # only if a ray did not enter one of the channels does it have any chance
         # of hitting the Bragg peak monitor:
-        mon = self.monitor.to_mccode(assembler)
+        mon = self.monitor.to_mccode(assembler, at=sample)
         mon.WHEN('secondary_cassette == -1')
 
     def add_to_graph(self, upstream: str | None, name: str, graph: DiGraph):

--- a/src/niess/components/aperture.py
+++ b/src/niess/components/aperture.py
@@ -1,5 +1,6 @@
 from scipp import Variable
 from mccode_antlr.assembler import Assembler
+from mccode_antlr.instr import Instance
 from .component import Component
 
 
@@ -34,12 +35,15 @@ class Jaw(Aperture):
         }
         return 'Slit', params
 
-    def to_mccode(self, assembler: Assembler):
+    def to_mccode(
+            self, assembler: Assembler,
+            at: Instance | str | None = None, rotate: Instance | str | None = None,
+    ):
         from ..mccode import ensure_runtime_line as ensure
         half = self.width.to(unit='m').value / 2
         ensure(assembler, f'{self.name}_l/"m" = {-half}')
         ensure(assembler, f'{self.name}_r/"m" = {half}')
-        return super().to_mccode(assembler)
+        return super().to_mccode(assembler, at, rotate)
 
 
 class Slit(Aperture):
@@ -54,7 +58,10 @@ class Slit(Aperture):
         }
         return 'Slit', params
 
-    def to_mccode(self, assembler: Assembler):
+    def to_mccode(
+            self, assembler: Assembler,
+            at: Instance | str | None = None, rotate: Instance | str | None = None,
+    ):
         from ..mccode import ensure_runtime_line as ensure
         half = self.width.to(unit='m').value / 2
         ensure(assembler, f'{self.name}_l/"m" = {-half}')
@@ -62,4 +69,4 @@ class Slit(Aperture):
         half = self.height.to(unit='m').value / 2
         ensure(assembler, f'{self.name}_b/"m" = {-half}')
         ensure(assembler, f'{self.name}_t/"m" = {half}')
-        return super().to_mccode(assembler)
+        return super().to_mccode(assembler, at, rotate)

--- a/src/niess/components/aperture.py
+++ b/src/niess/components/aperture.py
@@ -14,7 +14,13 @@ class Aperture(Component):
         orientation = cal['orientation']
         width = cal['width']
         height = cal['height']
-        return cls(name, position, orientation, width, height)
+        return cls(
+            name=name,
+            position=position,
+            orientation=orientation,
+            width=width,
+            height=height
+        )
 
 
 class Jaw(Aperture):

--- a/src/niess/components/chopper.py
+++ b/src/niess/components/chopper.py
@@ -58,7 +58,18 @@ class DiscChopper(Chopper):
         width = cal.get('width') # None is actually acceptable
         height = cal.get('height')  # None is acceptable, then slit extends to center
         offset = cal.get('offset', vector([0, 0, 0], unit='m'))
-        return cls(name, position, orientation, velocity, phase, radius, windows, width, height, offset)
+        return cls(
+            name=name,
+            position=position,
+            orientation=orientation,
+            velocity=velocity,
+            phase=phase,
+            radius=radius,
+            windows=windows,
+            width=width,
+            height=height,
+            offset=offset
+        )
 
 
     def __mccode__(self) -> tuple[str, dict]:

--- a/src/niess/components/chopper.py
+++ b/src/niess/components/chopper.py
@@ -1,6 +1,6 @@
 from scipp import Variable
 from .component import Component
-
+from mccode_antlr.instr import Instance
 from mccode_antlr.assembler import Assembler
 
 
@@ -94,12 +94,15 @@ class DiscChopper(Chopper):
             params['yheight'] = self.height.to(unit='m').value
         return 'DiskChopper', params
 
-    def to_mccode(self, assembler: Assembler):
+    def to_mccode(
+            self, assembler: Assembler,
+            at: Instance | str | None = None, rotate: Instance | str | None = None,
+    ):
         from ..mccode import ensure_runtime_line as ensure
         ensure(assembler, f'{self.name}speed/"Hz" = {self.speed.value}')
         ensure(assembler, f'{self.name}phase/"degree" = {self.phase.to(unit="deg").value}')
         # the offset is handled by super's to_mccode -- no problems.
-        return super().to_mccode(assembler)
+        return super().to_mccode(assembler, at, rotate)
 
 
 class FermiChopper(Chopper):

--- a/src/niess/components/component.py
+++ b/src/niess/components/component.py
@@ -5,6 +5,7 @@ from typing import ClassVar, Type
 from scipp import Variable
 from networkx import DiGraph
 from mccode_antlr.assembler import Assembler
+from mccode_antlr.instr import Instance
 
 # TODO: Add a 'tag' property to either Base or Component
 #       This is intended to represent an ESS Facility Breakdown Structure (FBS) tag,
@@ -97,7 +98,10 @@ class Component(Base, kw_only=True):
         """Return the component type name and parameters needed to produce a McCode instance"""
         return 'Arm', {}
 
-    def to_mccode(self, assembler: Assembler):
+    def to_mccode(
+            self, assembler: Assembler,
+            at: Instance | str | None = None, rotate: Instance | str | None = None,
+    ):
         from mccode_antlr.common.parameters import InstrumentParameter as InstPar
         from ..spatial import mccode_ordered_angles
         from ..mccode import ensure_runtime_parameter
@@ -109,10 +113,13 @@ class Component(Base, kw_only=True):
                 ensure_runtime_parameter(assembler, value)
                 pars[name] = str(value)
 
+        at_rel = 'ABSOLUTE' if at is None else at
+        rot_rel = 'ABSOLUTE' if rotate is None else rotate
+
         at = self.position
         if hasattr(self, 'offset'):
             at += getattr(self, 'offset')
-        at = at.to(unit='m').value
-        rot = mccode_ordered_angles(self.orientation)
+        at = (at.to(unit='m').value, at_rel)
+        rot = (mccode_ordered_angles(self.orientation), rot_rel)
 
         return assembler.component(self.name, comp, at=at, rotate=rot, parameters=pars)

--- a/src/niess/components/component.py
+++ b/src/niess/components/component.py
@@ -6,6 +6,10 @@ from scipp import Variable
 from networkx import DiGraph
 from mccode_antlr.assembler import Assembler
 
+# TODO: Add a 'tag' property to either Base or Component
+#       This is intended to represent an ESS Facility Breakdown Structure (FBS) tag,
+#       and should take precedence over 'name' for the purpose of making component graphs
+
 class Base(msgspec.Struct):
     __struct_field_types__: ClassVar[dict[str, Type]]
 
@@ -49,7 +53,7 @@ class Base(msgspec.Struct):
         return [name]
 
 
-class Component(Base):
+class Component(Base, kw_only=True):
     """Any component in the instrument.
 
     Note
@@ -68,17 +72,22 @@ class Component(Base):
         The orientation of the component instance in scipp quaternion form. This
         transforms the coordinate system of the component into the global coordinate
         system.
+    tag: str | None
+        The Facility Breakdown Structure (FBS) tag representing this component
     """
     name: str
     position: Variable
     orientation: Variable
+    # tag: str | None = None
 
     @classmethod
     def from_calibration(cls, calibration: dict):
         name = calibration['name']
         position = calibration['position']
         orientation = calibration['orientation']
-        return cls(name, position, orientation)
+        # tag = calibration.get('tag')
+        # return cls(name=name, position=position, orientation=orientation, tag=tag)
+        return cls(name=name, position=position, orientation=orientation)
 
     @classmethod
     def from_dict(cls, dictionary):

--- a/src/niess/components/filter.py
+++ b/src/niess/components/filter.py
@@ -33,7 +33,16 @@ class Filter(Component):
         temperature = cal.get('temperature', s(300., unit='K'))
         position = cal.get('position', v([0, 0, 0.], unit='m'))
         orientation = cal.get('orientation', r(v([0.,0, 0], unit='deg')))
-        return cls(name, position, orientation, width, height, length, composition, temperature)
+        return cls(
+            name=name,
+            position=position,
+            orientation=orientation,
+            width=width,
+            height=height,
+            length=length,
+            composition=composition,
+            temperature=temperature
+        )
 
     def __mccode__(self) -> tuple[str, dict]:
         params = dict()
@@ -77,4 +86,8 @@ class Attenuator(Filter):
 
 def make_aluminum(name, position, orientation, width, height, length):
     from scipp import scalar
-    return Filter(name, position, orientation, width, height, length, 'Al_sg225', scalar(300, unit='K'))
+    return Filter(
+        name=name, position=position, orientation=orientation,
+        width=width, height=height, length=length,
+        composition='Al_sg225', temperature=scalar(300, unit='K')
+    )

--- a/src/niess/components/filter.py
+++ b/src/niess/components/filter.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from scipp import Variable
 from .component import Component
 from mccode_antlr.assembler import Assembler
+from mccode_antlr.instr import Instance
 
 
 class Filter(Component):
@@ -74,11 +75,14 @@ class Attenuator(Filter):
     |  AKA Plexiglass, Lucite, Perspex, acrylic, etc.  |                          |
     | Polycarbonate                                    | 'Polycarbonate_C16O3H14' |
     """
-    def to_mccode(self, assembler: Assembler):
+    def to_mccode(
+            self, assembler: Assembler,
+            at: Instance | str | None = None, rotate: Instance | str | None = None,
+    ):
         from mccode_antlr.common import InstrumentParameter, Expr, Value, DataType, ObjectType, ShapeType
         parameter = InstrumentParameter.parse(f"int {self.name}_in = 0")
         assembler.instrument.add_parameter(parameter, ignore_repeated=True)
-        comp = super().to_mccode(assembler)
+        comp = super().to_mccode(assembler, at, rotate)
         var = Value(parameter.name, DataType.int, ObjectType.parameter, ShapeType.scalar)
         comp.WHEN(Expr(var))
         return comp

--- a/src/niess/components/guide.py
+++ b/src/niess/components/guide.py
@@ -64,7 +64,18 @@ class StraightGuide(Guide):
             raise ValueError('StraightGuide does not support multiple m values')
         width = cal['width']
         height = cal['height']
-        return cls(name, position, orientation, length, left, right, top, bottom, width, height)
+        return cls(
+            name=name,
+            position=position,
+            orientation=orientation,
+            length=length,
+            left=left,
+            right=right,
+            top=top,
+            bottom=bottom,
+            width=width,
+            height=height
+        )
 
     def __mccode__(self) -> tuple[str, dict]:
         p = {
@@ -152,8 +163,20 @@ class TaperedGuide(Guide):
         out_width = cal.get('out_width', cal.get('width'))
         in_height = cal.get('in_height', cal.get('height'))
         out_height = cal.get('out_height', cal.get('height'))
-        return cls(name, position, orientation, length, left, right, top, bottom,
-                   in_width, out_width, in_height, out_height)
+        return cls(
+            name=name,
+            position=position,
+            orientation=orientation,
+            length=length,
+            left=left,
+            right=right,
+            top=top,
+            bottom=bottom,
+            in_width=in_width,
+            out_width=out_width,
+            in_height=in_height,
+            out_height=out_height
+        )
 
     def __mccode__(self) -> tuple[str, dict]:
         p = {
@@ -227,7 +250,11 @@ class PartialEllipse(Base):
         major = cal['major']
         minor = cal['minor']
         offset = cal['offset']
-        return cls(major, minor, offset)
+        return cls(
+            major=major,
+            minor=minor,
+            offset=offset
+        )
 
     def mccode_pars(self, post):
         p = {
@@ -272,7 +299,18 @@ class EllipticGuide(Guide):
         horizontal = PartialEllipse.from_calibration(gl, cal.get('horizontal'))
         vertical = PartialEllipse.from_calibration(gl, cal.get('vertical'))
 
-        return cls(name, position, orientation, length, left, right, top, bottom, horizontal, vertical)
+        return cls(
+            name=name,
+            position=position,
+            orientation=orientation,
+            length=length,
+            left=left,
+            right=right,
+            top=top,
+            bottom=bottom,
+            horizontal=horizontal,
+            vertical=vertical
+        )
 
     def __mccode__(self) -> tuple[str, dict]:
         from scipp import sum

--- a/src/niess/components/guide.py
+++ b/src/niess/components/guide.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Union
 from mccode_antlr.assembler import Assembler
+from mccode_antlr.instr import Instance
 from networkx import DiGraph
 from scipp import Variable
 from .component import Base, Component
@@ -330,9 +331,12 @@ class EllipticGuide(Guide):
 
         return 'Elliptic_guide_gravity', p
 
-    def to_mccode(self, assembler: Assembler):
+    def to_mccode(
+            self, assembler: Assembler,
+            at: Instance | str | None = None, rotate: Instance | str | None = None,
+    ):
         if isinstance(self.left, tuple):
             assembler.declare_array('double', f'{self.name}_lens', self.length.to(unit='m').values)
             for n in ('left', 'right', 'top', 'bottom'):
                 assembler.declare_array('double', f'{self.name}_{n}', getattr(self, n))
-        super().to_mccode(assembler)
+        super().to_mccode(assembler, at, rotate)

--- a/src/niess/components/monitors.py
+++ b/src/niess/components/monitors.py
@@ -1,25 +1,26 @@
 from mccode_antlr.assembler import Assembler
+from mccode_antlr.instr.instance import Instance
 from scipp import Variable
 from .component import Component
 
 # Monitors used on BIFROST, which are limited within McStas to always produce histograms
 
-def nexus_structure_metadata(topic, *, variables, constants):
+def nexus_structure_metadata(topic: str, source: str, *, variables, constants):
     from json import dumps
     from mccode_antlr.common import MetaData
     from mccode_to_kafka.writer import da00_dataarray_config
-    # TODO uodate eniius.utils.mccode_component_eniius_data to use ('*', 'application/json') instead of
+    # TODO update eniius.utils.mccode_component_eniius_data to use ('*', 'application/json') instead of
     #      only ('eniius_data', 'json')
     # The correct JSON to encode is a dictionary with a single key, 'data', which itself is a dictionary with
     # the keys 'type' and 'value'. The value of 'type' is 'dict' and the value of 'value' is the actual NeXus structure.
     # This is very hacky and is (currently) necessary to escape parsing within eniius.
 
-    struct = da00_dataarray_config(topic, source='mccode-to-kafka', variables=variables, constants=constants)
+    struct = da00_dataarray_config(topic, source=source, variables=variables, constants=constants)
 
     return MetaData.from_instance_tokens(topic, 'application/json', 'nexus_structure_stream_data', dumps(struct))
 
 
-def add_frame_monitor_metadata(inst, n):
+def add_monitor_metadata(instr_name: str, inst: Instance, n):
     from mccode_to_kafka.writer import da00_variable_config
     axes = {
         'signal': {'unit': 'counts', 'label': f'{inst.name} counts', 'shape': [n]},
@@ -33,13 +34,30 @@ def add_frame_monitor_metadata(inst, n):
     }
     variables = [configs['signal'], configs['errors']]
     constants = [configs['t']]
-    metadata = nexus_structure_metadata(topic=inst.name, variables=variables,
-                                        constants=constants)
+    topic = f'{instr_name.lower()}_beam_monitor'
+    source = inst.name  # 'cbm1', 'cbm2', etc. in the real instrument, for now
+    metadata = nexus_structure_metadata(
+        topic=topic, source=source, variables=variables, constants=constants
+    )
     inst.add_metadata(metadata)
     return inst
 
 
-class FissionChamber(Component):
+class FrameMonitor(Component):
+    @staticmethod
+    def time_bins():
+        return int(1e6 / 14.0 / 7) # 7 microsecond bins
+
+    def to_mccode(self, assembler: Assembler):
+        inst = super().to_mccode(assembler)
+        # Build the NeXus Structure entry to point to the correct Kafka stream
+        return add_monitor_metadata(assembler.name, inst, self.time_bins())
+
+    def __partial__mccode__(self) -> tuple[str, dict]:
+        return 'Frame_monitor', {'nt': self.time_bins(), 'frequency': 14.0}
+
+
+class FissionChamber(FrameMonitor):
     """Zero-dimensional fission chamber monitor.
     Outputs events without any spatial information.
     """
@@ -58,21 +76,15 @@ class FissionChamber(Component):
         return cls(name, position, orientation, width, height, thickness)
 
     def __mccode__(self) -> tuple[str, dict]:
-        p = {
+        t, p = self.__partial__mccode__()
+        p.update({
             'xwidth': self.width.to(unit='m').value,
             'yheight': self.height.to(unit='m').value,
-            'nt': int(1e6 / 14.0 / 7),  # 7 microsecond bins
-            'frequency': 14.0,
-        }
-        return 'Frame_monitor', p
-
-    def to_mccode(self, assembler: Assembler):
-        inst = super().to_mccode(assembler)
-        # Build the NeXus Structure entry to point to the correct Kafka stream
-        return add_frame_monitor_metadata(inst, self.__mccode__()[1]['nt'])
+        })
+        return t, p
 
 
-class He3Monitor(Component):
+class He3Monitor(FrameMonitor):
     """Zero-dimensional He3 tube monitor.
     Outputs events without any spatial information.
     """
@@ -88,24 +100,21 @@ class He3Monitor(Component):
         radius = cal['radius']
         length = cal['length']
         pressure = cal['pressure']
-        return cls(name, position, orientation, radius, length, pressure)
+        return cls(
+            name=name, position=position, orientation=orientation,
+            radius=radius, length=length, pressure=pressure
+        )
 
     def __mccode__(self) -> tuple[str, dict]:
-        p = {
+        t, p = self.__partial__mccode__()
+        p.update({
             'xwidth': 2 * self.radius.to(unit='m').value,
             'yheight': self.length.to(unit='m').value,
-            'nt': int(1e6 / 14.0 / 7),  # 7 microsecond bins
-            'frequency': 14.0,
-        }
-        return 'Frame_monitor', p
-
-    def to_mccode(self, assembler: Assembler):
-        inst = super().to_mccode(assembler)
-        # Build the NeXus Structure entry to point to the correct Kafka stream
-        return add_frame_monitor_metadata(inst, self.__mccode__()[1]['nt'])
+        })
+        return t, p
 
 
-class BeamCurrentMonitor(Component):
+class BeamCurrentMonitor(FrameMonitor):
     """Zero-dimensional beam current monitor.
     Outputs a current sampled at a configurable frequency.
     """
@@ -125,27 +134,26 @@ class BeamCurrentMonitor(Component):
         sample_rate = cal.get('sample_rate', cal.get('frequency'))
         if sample_rate is None:
             raise ValueError(f'The sample rate for {name} must be defined')
-        return cls(name, position, orientation, width, height, thickness, sample_rate)
+        return cls(
+            name=name, position=position, orientation=orientation,
+            width=width, height=height, thickness=thickness, sample_rate=sample_rate
+        )
 
-    def __mccode__(self) -> tuple[str, dict]:
+    def time_bins(self):
         from scipp import scalar
         source_frequency = scalar(14.0, unit='Hz')
-        nt = int((self.sample_rate.to(unit='Hz') / source_frequency).value)
-        p = {
+        return int((self.sample_rate.to(unit='Hz') / source_frequency).value)
+
+    def __mccode__(self) -> tuple[str, dict]:
+        t, p = self.__partial__mccode__()
+        p.update({
             'xwidth': self.width.to(unit='m').value,
             'yheight': self.height.to(unit='m').value,
-            'nt': nt,
-            'frequency': source_frequency.to(unit='Hz').value,
-        }
-        return 'Frame_monitor', p
-
-    def to_mccode(self, assembler: Assembler):
-        inst = super().to_mccode(assembler)
-        # Build the NeXus Structure entry to point to the correct Kafka stream
-        return add_frame_monitor_metadata(inst, self.__mccode__()[1]['nt'])
+        })
+        return t, p
 
 
-class GEM2D(Component):
+class GEM2D(FrameMonitor):
     """Two-dimensional Gas Electron Multiplier monitor.
     Outputs events on X or Y strips (without coincidence) or at (X, Y) point
     (with coincidence).
@@ -168,23 +176,16 @@ class GEM2D(Component):
         thickness = cal.get('thickness', cal.get('length'))
         x_strips = cal.get('x_strips', cal.get('nx', 1))
         y_strips = cal.get('y_strips', cal.get('ny', 1))
-        return cls(name, position, orientation, width, height, thickness, x_strips, y_strips)
+        return cls(
+            name=name, position=position, orientation=orientation,
+            width=width, height=height, thickness=thickness,
+            x_strips=x_strips, y_strips=y_strips
+        )
 
     def __mccode__(self) -> tuple[str, dict]:
-        from scipp import scalar
-        source_frequency = scalar(14.0, unit='Hz')
-        # nt = 1000 # 71.42 µs bins
-        nt = 10000 # 7.142 µs bins
-        # nt = 71428 # 1.00001 µs bins
-        p = {
+        t, p = self.__partial__mccode__()
+        p.update({
             'xwidth': self.width.to(unit='m').value,
             'yheight': self.height.to(unit='m').value,
-            'nt': nt,
-            'frequency': source_frequency.to(unit='Hz').value,
-        }
-        return 'Frame_monitor', p
-
-    def to_mccode(self, assembler: Assembler):
-        inst = super().to_mccode(assembler)
-        # Build the NeXus Structure entry to point to the correct Kafka stream
-        return add_frame_monitor_metadata(inst, self.__mccode__()[1]['nt'])
+        })
+        return t, p

--- a/src/niess/components/monitors.py
+++ b/src/niess/components/monitors.py
@@ -73,7 +73,14 @@ class FissionChamber(FrameMonitor):
         width = cal['width']
         height = cal['height']
         thickness = cal.get('thickness', cal.get('length'))
-        return cls(name, position, orientation, width, height, thickness)
+        return cls(
+            name=name,
+            position=position,
+            orientation=orientation,
+            width=width,
+            height=height,
+            thickness=thickness
+        )
 
     def __mccode__(self) -> tuple[str, dict]:
         t, p = self.__partial__mccode__()

--- a/src/niess/components/monitors.py
+++ b/src/niess/components/monitors.py
@@ -48,8 +48,11 @@ class FrameMonitor(Component):
     def time_bins():
         return int(1e6 / 14.0 / 7) # 7 microsecond bins
 
-    def to_mccode(self, assembler: Assembler):
-        inst = super().to_mccode(assembler)
+    def to_mccode(
+            self, assembler: Assembler,
+            at: Instance | str | None = None, rotate: Instance | str | None = None,
+    ):
+        inst = super().to_mccode(assembler, at, rotate)
         # Build the NeXus Structure entry to point to the correct Kafka stream
         return add_monitor_metadata(assembler.name, inst, self.time_bins())
 

--- a/src/niess/components/source.py
+++ b/src/niess/components/source.py
@@ -58,10 +58,25 @@ class ESSource(Source):
         n_pulses = cal.get('n_pulses', None)
         accelerator_power = cal.get('accelerator_power', None)
 
-        return cls(name, position, orientation, sector, beamline, height, cold_frac,
-                   focus_distance, focus_width, focus_height, cold_performance,
-                   thermal_performance, wavelength_minimum, wavelength_maximum,
-                   latest_emission_time, n_pulses, accelerator_power)
+        return cls(
+            name=name,
+            position=position,
+            orientation=orientation,
+            sector=sector,
+            beamline=beamline,
+            height=height,
+            cold_frac=cold_frac,
+            focus_distance=focus_distance,
+            focus_width=focus_width,
+            focus_height=focus_height,
+            cold_performance=cold_performance,
+            thermal_performance=thermal_performance,
+            wavelength_minimum=wavelength_minimum,
+            wavelength_maximum=wavelength_maximum,
+            latest_emission_time=latest_emission_time,
+            n_pulses=n_pulses,
+            accelerator_power=accelerator_power
+        )
 
     def __mccode__(self) -> tuple[str, dict]:
         from ..utilities import variable_value_or_parameter as value_or

--- a/src/niess/components/source.py
+++ b/src/niess/components/source.py
@@ -1,8 +1,9 @@
 from typing import Optional, Union
 
 from scipp import Variable
-
+from mccode_antlr.instr import Instance
 from mccode_antlr.common.parameters import InstrumentParameter
+from mccode_antlr.assembler import Assembler
 from .component import Component
 
 
@@ -105,11 +106,14 @@ class ESSource(Source):
 
         return 'ESS_butterfly', pars
 
-    def to_mccode(self, assembler):
+    def to_mccode(
+            self, assembler: Assembler,
+            at: Instance | str | None = None, rotate: Instance | str | None = None,
+    ):
         from ..mccode import ensure_runtime_parameter
         for field in self.fields():
             p = getattr(self, field)
             if isinstance(p, InstrumentParameter):
                 ensure_runtime_parameter(assembler, p)
-        return super().to_mccode(assembler)
+        return super().to_mccode(assembler, at, rotate)
 


### PR DESCRIPTION
- Adds an optional tag to all `Component` objects to allow for (eventual) addition of ESS FBS information.
- Refactors the monitors to use a common intermediate class that defines common streaming-data configuration information, and fixed the stream topic and producer names
- Adds the option to locate all of BIFROST in the ESS TCS for comparison with as-built CAD files, fixes #23 
- Adds a missing guide segment in Unit 9 of the BIFROST curved guide, correcting the length of the instrument, fixed #22 
- Allows for relative positioning through `Component.to_mccode`, and places the BIFROST Bragg peak monitor at the right place, fixes #21 