### PR TITLE
[Update] mccode-antlr v0.19.0 and minor associated fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,11 +26,11 @@ dependencies = [
   "scipp>=25.11.0",
   "numpy",
   "scipy",
-  "mccode-antlr>=0.18.4",
+  "mccode-antlr>=0.19.0",
   "mccode-to-kafka>=0.2.2",
   "msgspec>=0.20.0",
-  "networkx>=3.6",
-  "ncrystal>=4.2.4" # required for B4C_sg166_BoronCarbide
+  "networkx>=3.6", # required for B4C_sg166_BoronCarbide
+  "ncrystal>=4.2.4",
 ]
 
 [project.optional-dependencies]

--- a/src/niess/components/filter.py
+++ b/src/niess/components/filter.py
@@ -105,12 +105,11 @@ class Attenuator(NCrystalFilter):
             self, assembler: Assembler,
             at: Instance | str | None = None, rotate: Instance | str | None = None,
     ):
-        from mccode_antlr.common import InstrumentParameter, Expr, Value, DataType, ObjectType, ShapeType
+        from mccode_antlr.common import InstrumentParameter, Expr
         parameter = InstrumentParameter.parse(f"int {self.name}_in = 0")
         assembler.instrument.add_parameter(parameter, ignore_repeated=True)
         comp = super().to_mccode(assembler, at, rotate)
-        var = Value(parameter.name, DataType.int, ObjectType.parameter, ShapeType.scalar)
-        comp.WHEN(Expr(var))
+        comp.WHEN(Expr.parameter(parameter.name))
         return comp
 
 

--- a/tests/test_bifrost.py
+++ b/tests/test_bifrost.py
@@ -4,23 +4,6 @@
 from operator import getitem
 
 
-def get_mccode_registries():
-    from mccode_antlr.reader import GitHubRegistry
-
-    registries = ['mcstas-chopper-lib', 'mcstas-transformer', 'mcstas-detector-tubes',
-                  'mcstas-epics-link', 'mcstas-frame-tof-monitor', 'mccode-mcpl-filter',
-                  'mcstas-monochromator-rowland', 'mcstas-slit-radial']
-    registries = [GitHubRegistry(
-        name,
-        url=f'https://github.com/mcdotstar/{name}',
-        filename='pooch-registry.txt',
-        version='main'
-    ) for name in registries]
-
-    return registries
-
-
-
 def test_bifrost_whole():
     from niess.bifrost.parameters import primary_parameters, tank_parameters
     from niess.bifrost import Tank, Primary
@@ -36,7 +19,7 @@ def test_bifrost_mccode():
     from mccode_antlr.assembler import Assembler
     from pathlib import Path
 
-    bifrost = Assembler('bifrost', registries=get_mccode_registries(), flavor=Flavor.MCSTAS)
+    bifrost = Assembler('bifrost', flavor=Flavor.MCSTAS)
 
     primary = Primary.from_calibration(primary_parameters())
     primary.to_mccode(bifrost)


### PR DESCRIPTION
This pull request makes several improvements to dependency management and code simplification, particularly around the use of the `mccode_antlr` library and test registry setup. The most significant changes include updating the `mccode-antlr` dependency version, simplifying imports and usage in `filter.py`, and removing redundant registry code from tests.

Dependency updates:

* Updated the `mccode-antlr` dependency in `pyproject.toml` from version `0.18.4` to `0.19.0`, ensuring compatibility with newer features and bug fixes.

Code simplification and cleanup:

* Simplified imports in `src/niess/components/filter.py` by removing unused classes and using `Expr.parameter(parameter.name)` instead of manually constructing a `Value` object, making the code easier to read and maintain.
* Removed the `get_mccode_registries()` function from `tests/test_bifrost.py`, eliminating unnecessary registry setup code.
* Updated the `test_bifrost_mccode()` function in `tests/test_bifrost.py` to construct the `Assembler` without the now-removed registry argument, further streamlining test setup.

These changes collectively modernize dependencies and reduce complexity in both the main codebase and test suite.