### PR TITLE
Fix bifrost filter in graph

### DIFF
--- a/src/niess/__about__.py
+++ b/src/niess/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2025-present Gregory Tucker <gregory.tucker@ess.eu>
 #
 # SPDX-License-Identifier: MIT
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/src/niess/bifrost/channel.py
+++ b/src/niess/bifrost/channel.py
@@ -202,8 +202,10 @@ class Channel(Base):
                           settings=settings, detector_when=detector_when, detector_extend=detector_extend, **kwargs)
 
     def add_to_graph(self, upstream: str | None, name: str, graph: DiGraph):
-        cassette = f'{name}_arm'
-        graph.add_node(cassette)
+        radial_collimator_filter = f'{name}_radial_filter_collimator'
         if upstream is not None:
-            graph.add_edge(upstream, cassette)
-        return [arm.add_to_graph(cassette, f"{name}_{1 + arm_index}", graph) for arm_index, arm in enumerate(self.pairs)]
+            graph.add_edge(upstream, radial_collimator_filter)
+        # cassette = f'{name}_arm'
+        # graph.add_edge(radial_collimator_filter, cassette)
+        # # Previously this put all analyzers downstream of a common "cassette" node
+        return [arm.add_to_graph(radial_collimator_filter, f"{name}_{1 + arm_index}", graph) for arm_index, arm in enumerate(self.pairs)]

--- a/src/niess/bifrost/channel.py
+++ b/src/niess/bifrost/channel.py
@@ -205,7 +205,6 @@ class Channel(Base):
         radial_collimator_filter = f'{name}_radial_filter_collimator'
         if upstream is not None:
             graph.add_edge(upstream, radial_collimator_filter)
-        # cassette = f'{name}_arm'
-        # graph.add_edge(radial_collimator_filter, cassette)
-        # # Previously this put all analyzers downstream of a common "cassette" node
-        return [arm.add_to_graph(radial_collimator_filter, f"{name}_{1 + arm_index}", graph) for arm_index, arm in enumerate(self.pairs)]
+        cassette = f'{name}_arm'
+        graph.add_edge(radial_collimator_filter, cassette)
+        return [arm.add_to_graph(cassette, f"{name}_{1 + arm_index}", graph) for arm_index, arm in enumerate(self.pairs)]


### PR DESCRIPTION
This pull request includes a version bump and an update to the instrument graph construction logic for channels. The main focus is on improving the representation of components in the instrument's directed graph.

Instrument graph construction improvements:

* In `channel.py`, the `add_to_graph` method now inserts a `radial_filter_collimator` node between the upstream component and the cassette (`arm`) node, ensuring the filter/collimator is properly represented in the instrument's graph structure.

Version update:

* The project version in `__about__.py` is incremented from `0.2.0` to `0.2.1` to reflect these changes.