### PR TITLE
[Fix] the analyzer blades of BIFROST are tilted to focus on the detector

### DIFF
--- a/src/niess/bifrost/analyzer.py
+++ b/src/niess/bifrost/analyzer.py
@@ -109,7 +109,8 @@ class Analyzer(Base):
             show_construction='showconstruction',
             angle_h=ver_cov.to(unit='degree').value,
             source=f'"{source}"',
-            sink=f'"{sink}"'
+            sink=f'"{sink}"',
+            focush='"exact"',
         )
         return params
 


### PR DESCRIPTION
The analyzers of BIFROST are made up of multiple flat single crystals arranged on the circumference of a circle which also passes through the sample position and the center of the central tube of the triplet associated with the analyzer. This Rowland geometry ensures that all analyzers reflect the same energy to the detector _independent_ of their orientation, and allows for the detectors at higher and lower scattering angle to receive slightly different final energy neutrons.

A McStas component, `Monochromator_Rowland.comp`, calculates the positions of the analyzer blades to reduce the complexity of the .instr representation of BIFROST. 
One long-standing deficiency of the use-here of `Monochromator_Rowland` is the failure to enable per-crystal rotations which ensure that each is oriented to reflect the analyzer energy optimally. This deficiency is the result of a lack of confidence in the component's focus calculation. 

[Recent testing improvements for `Monochromator_Rowland`](https://github.com/mcdotstar/mcstas-monochromator-rowland/pull/1) provide the necessary confidence that the `focush = "exact"` code-path in the component provides the correct best-focusing condition.

This small PR enables the exact focusing, which should provide a noticable intensity increase as it is, effectively, a move from the focusing power 0 (flat) case to focusing power 1 in the following contrived scan
<img width="593" height="455" alt="image" src="https://github.com/user-attachments/assets/ef4bb666-9adb-423a-b44f-6d893c885935" />
