### PR TITLE
[Add] optional extra information for representing components

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,38 @@ Primary.from_calibration(primary_parameters()).to_mccode(assembler)
 Tank.from_calibration(tank_parameters()).to_mccode(assembler, 'sample_coordinates')
 
 ```
+
+## Optional CAD information
+
+When a `niess` object is exported to `mccode_antlr`, the emitted component instances
+can also receive niess-specific `METADATA` describing their originating niess type. This
+can be used to build a more faithful CAD representation than the default `MCDISPLAY`
+fallback:
+
+```python
+from scipp import vector, scalar
+from scipp.spatial import rotations_from_rotvecs
+from mccode_antlr import Flavor
+from mccode_antlr.assembler import Assembler
+from niess.components import Guide
+from niess.mccode import add_niess_metadata
+from niess.brep import instrument_to_assembly, save_step
+
+assembler = Assembler('instrument', flavor=Flavor.MCSTAS)
+
+width, height, substrate_thickness = 0.1, 0.2, 0.005  # m
+guide = Guide(
+    name="guide", 
+    position=vector([0, 0, 0], unit='m'), 
+    orientation=rotations_from_rotvecs(vector([0, 0, 0], unit='degree')),
+    length=scalar(1., unit='m'),
+    left=1.,  right=1., top=1., bottom=1. # m-values are unitless
+)
+instance = guide.to_mccode(assembler, insert_brep_metadata=True)
+# Override the standard extra information to include the guide substrate thickness,
+# which is not represented in McStas but can be drawn in CAD software
+add_niess_metadata(instance, guide, extra={'substrate': substrate_thickness})
+
+assembly = instrument_to_assembly(assembler.instrument)
+save_step(assembly, 'bifrost.step')
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
   "scipp>=25.11.0",
   "numpy",
   "scipy",
-  "mccode-antlr>=0.19.0",
+  "mccode-antlr>=0.20.0",
   "mccode-to-kafka>=0.2.2",
   "msgspec>=0.20.0",
   "networkx>=3.6", # required for B4C_sg166_BoronCarbide

--- a/src/niess/__init__.py
+++ b/src/niess/__init__.py
@@ -11,14 +11,18 @@ from .components import (
     DiscreteTube,
     He3Tube
 )
+from .brep import NiessBRepRegistry, instrument_to_assembly, save_step
 
 __all__ = [
-DirectSecondary,
+    DirectSecondary,
     IndirectSecondary,
     IdealCrystal,
     Crystal,
     Wire,
     DiscreteWire,
     DiscreteTube,
-    He3Tube
+    He3Tube,
+    NiessBRepRegistry,
+    instrument_to_assembly,
+    save_step,
 ]

--- a/src/niess/brep/__init__.py
+++ b/src/niess/brep/__init__.py
@@ -1,0 +1,10 @@
+from .registry import NiessBRepRegistry
+from .provenance import NiessProvenance
+from .components import instrument_to_assembly, save_step
+
+__all__ = [
+    NiessBRepRegistry,
+    NiessProvenance,
+    instrument_to_assembly,
+    save_step,
+]

--- a/src/niess/brep/components.py
+++ b/src/niess/brep/components.py
@@ -1,0 +1,339 @@
+from __future__ import annotations
+
+from math import sqrt
+
+from niess.components.component import Component
+from niess.components.aperture import Jaw, Slit
+from niess.components.filter import Attenuator, NCrystalFilter, RadialFilterCollimator
+from niess.components.guide import EllipticGuide, StraightGuide, TaperedGuide
+from niess.components.source import ESSource
+from .provenance import NiessProvenance
+from .registry import DEFAULT_BREP_REGISTRY
+
+_APERTURE_THICKNESS = 1e-4
+
+
+def _bd():
+    import build123d as bd
+    return bd
+
+
+def _param(params: dict[str, float], name: str, default: float | None = None):
+    if name in params:
+        return float(params[name])
+    if default is not None:
+        return default
+    raise KeyError(name)
+
+
+def _provenance_value(
+        provenance: NiessProvenance | None,
+        key: str,
+        default: float | None = None,
+):
+    if provenance is not None and key in provenance.extra:
+        return float(provenance.extra[key])
+    if default is not None:
+        return default
+    raise KeyError(key)
+
+
+def _box(width: float, height: float, length: float):
+    bd = _bd()
+    return bd.Box(float(width), float(height), float(length))
+
+
+def _loft_rectangles(in_width: float, in_height: float, out_width: float, out_height: float, length: float):
+    bd = _bd()
+    half = length / 2
+    with bd.BuildPart() as build:
+        with bd.BuildSketch(bd.Plane(origin=(0, 0, -half))):
+            bd.Rectangle(in_width, in_height)
+        with bd.BuildSketch(bd.Plane(origin=(0, 0, half))):
+            bd.Rectangle(out_width, out_height)
+        bd.loft()
+    return build.part
+
+
+def _loft_ellipses(in_width: float, in_height: float, out_width: float, out_height: float, length: float):
+    bd = _bd()
+    half = length / 2
+    with bd.BuildPart() as build:
+        with bd.BuildSketch(bd.Plane(origin=(0, 0, -half))):
+            bd.Ellipse(in_width / 2, in_height / 2)
+        with bd.BuildSketch(bd.Plane(origin=(0, 0, half))):
+            bd.Ellipse(out_width / 2, out_height / 2)
+        bd.loft()
+    return build.part
+
+
+def _ellipse_span(major: float, minor: float, offset: float, z: float):
+    if major == 0:
+        return 0.0
+    reduced = 1.0 - ((offset + z) / major) ** 2
+    return 2.0 * minor * sqrt(max(0.0, reduced))
+
+
+class _SafeInstrumentDisplay:
+    def __init__(self, instr):
+        from mccode_antlr.display.component_display import ComponentDisplay
+
+        self._instr = instr
+        self._components = {}
+        for instance in instr.components:
+            try:
+                component_display = ComponentDisplay(instance.type)
+                if not component_display.is_empty():
+                    self._components[instance.name] = component_display
+            except Exception:
+                continue
+
+
+
+def _shell_from_polygons(vertices, faces):
+    bd = _bd()
+    bd_faces = [
+        bd.Face(
+            bd.Wire.make_polygon([vertices[i] for i in face], close=True)
+        ) for face in faces
+    ]
+    return bd.Shell(bd_faces)
+
+
+def _solid_from_polygons(vertices, faces):
+    bd = _bd()
+    return bd.Solid(_shell_from_polygons(vertices, faces))
+
+
+def _rectangular_prism(w1: float, h1: float, w2: float, h2: float, length: float):
+    return _solid_from_polygons([
+        [-w1, -h1, 0], [w1, -h1, 0], [w1, h1, 0], [-w1, h1, 0],
+        [-w2, -h2, length], [w2, -h2, length], [w2, h2, length], [-w2, h2, length],
+    ], [
+        [0, 1, 2, 3], [1, 5, 6, 2], [2, 6, 7, 3], [3, 7, 4, 0], [0, 4, 5, 1],
+        [7, 6, 5, 4]
+    ]
+    )
+
+
+@DEFAULT_BREP_REGISTRY.register(StraightGuide)
+def build_straight_guide(_provenance, _instance, params: dict[str, float]):
+    bd = _bd()
+    substrate = _provenance.extra.get('substrate', 0.01)
+    z = _param(params, 'l')
+    w = _param(params, 'w1')/2
+    h = _param(params, 'h1')/2
+    inner = _rectangular_prism(w, h, w, h, z)
+    w += substrate
+    h += substrate
+    outer = _rectangular_prism(w, h, w, h, z)
+
+    guide = outer - inner
+    guide.label = _instance.name
+    guide.color = bd.Color(0.5, 0, 0, alpha=0.5)
+    return guide
+
+
+@DEFAULT_BREP_REGISTRY.register(TaperedGuide)
+def build_tapered_guide(_provenance, _instance, params: dict[str, float]):
+    bd = _bd()
+    substrate = _provenance.extra.get('substrate', 0.01)
+    z = _param(params, 'l')
+    w1 = _param(params, 'w1')/2
+    h1 = _param(params, 'h1')/2
+    w2 = _param(params, 'w2')/2
+    h2 = _param(params, 'h2')/2
+    inner = _rectangular_prism(w1, h1, w2, h2, z)
+    outer = _rectangular_prism(w1 + substrate, h1 + substrate, w2 + substrate, h2 + substrate, z)
+
+    guide = outer - inner
+    guide.label = _instance.name
+    guide.color = bd.Color(0.75, 0, 0, alpha=0.5)
+    return guide
+
+
+def _ellipse_parameters_from_widths(params: dict[str, float]):
+    from numpy import sqrt
+
+    def parameters(which, w, i, o, l):
+        foci = i + l + o
+        offset = foci / 2 - i
+        if 'mid' in which:
+            minor = w / 2
+            major = sqrt(foci ** 2 + minor ** 2) / 2
+        else:
+            t, b = (o, i) if 'entrance' in which else (i, o)
+            t += l
+            w /= 2
+            b = sqrt(b * b + w * w / 4) + sqrt(t * t + w * w / 4)
+            major = b / 2
+            minor = sqrt(b * b - foci * foci) / 2
+        return major, minor, offset
+
+    pars = dict(xw='xwidth', xi='linxw', xo='loutxw', yw='yheight', yi='linyh', yo='loutyh', l='l')
+    p = {k: params[v] for k, v in pars.items()}
+
+    print(params)
+    dim_at = str(params['dimensionsAt'])
+    major_x, minor_x, offset_x = parameters(dim_at, p['xw'], p['xi'], p['xo'], p['l'])
+    major_y, minor_y, offset_y = parameters(dim_at, p['yw'], p['yi'], p['yo'], p['l'])
+
+    return {
+        'major_x': major_x, 'minor_x': minor_x, 'offset_x': offset_x,
+        'major_y': major_y, 'minor_y': minor_y, 'offset_y': offset_y,
+        'l': p['l'],
+    }
+
+def _elliptic_guide_ellipse_parameters(params: dict[str, float]):
+    # Elliptic_guide_gravity uses a large number of parameters
+    # If the following 6 are present we should use them preferentially
+    bases = {'major': 'majorAxis', 'minor': 'minorAxis', 'offset': 'majorAxisoffset'}
+    ext = {'x': 'xw', 'y': 'yh'}
+    names = {f'{a}_{b}': f'{f}{s}' for a, f in bases.items() for b, s in ext.items()}
+    pars = {k: params.get(v) for k, v in names.items()}
+
+    if len(undef := [x for x in pars.values() if x is None]) == 0:
+        pars['l'] = params.get('l')
+    elif len(undef) < len(pars):
+        from loguru import logger
+        msg = f'Only {len(pars)-len(undef)} of {len(pars)} best parameters are defined'
+        logger.warning(f'Likely error state in Elliptic guide brep: {msg}')
+
+    if len(undef):
+        # But fall back to calculating axes and offsets from widths and lengths
+        pars = _ellipse_parameters_from_widths(params)
+
+    return pars
+
+
+@DEFAULT_BREP_REGISTRY.register(EllipticGuide)
+def build_elliptic_guide(_provenance, _instance, params: dict[str, float]):
+    from numpy import ceil, sqrt, arange
+    bd = _bd()
+    resolution = _provenance.extra.get('resolution', 0.5)
+    substrate = _provenance.extra.get('substrate', 0.01)
+
+    p = _elliptic_guide_ellipse_parameters(params)
+
+    # print(f'Elliptic guide {_instance.name} parameters: {p}')
+
+    def width_at(minor, major, at):
+        return 0 if abs(at) > major else float(minor * sqrt(1 - (at/major)**2))
+
+    count = int(ceil(p['l'] / resolution))
+    rings = arange(count + 1) / count
+    inner_vertices, outer_vertices = [], []
+    for r in rings:
+        z = float(r * p['l'])
+        w = width_at(p['minor_x'], p['major_x'], -p['offset_x'] - p['minor_x'] + z)
+        h = width_at(p['minor_y'], p['major_y'], -p['offset_y'] - p['minor_y'] + z)
+        vs = [(-w, -h, z), (+w, -h, z), (+w, +h, z), (-w, +h, z)]
+        inner_vertices.extend(vs)
+        w += substrate
+        h += substrate
+        vs = [(-w, -h, z), (+w, -h, z), (+w, +h, z), (-w, +h, z)]
+        outer_vertices.extend(vs)
+
+    faces = [[0, 1, 2, 3]]
+    for i in range(count):
+        j0, j1, j2, j3, j4, j5, j6, j7 = [4 * i + k for k in range(8)]
+        faces.extend([[j0, j1, j5, j4], [j1, j2, j6, j5], [j2, j3, j7, j6], [j3, j0, j4, j7]])
+    n = len(inner_vertices)
+    faces.append([n-1, n-2, n-3, n-4])
+
+    outer = _solid_from_polygons(outer_vertices, faces)
+    inner = _solid_from_polygons(inner_vertices, faces)
+
+    x = outer - inner
+    x.label = _instance.name
+    x.color = bd.Color('red', alpha=0.5)
+    return x
+
+
+@DEFAULT_BREP_REGISTRY.register(Slit)
+@DEFAULT_BREP_REGISTRY.register(Jaw)
+def build_aperture(provenance: NiessProvenance | None, _instance, params: dict[str, float]):
+    width = provenance and provenance.extra.get('width')
+    height = provenance and provenance.extra.get('height')
+    if width is None:
+        if 'xwidth' in params:
+            width = params['xwidth']
+        else:
+            width = params.get('xmax', 0.0) - params.get('xmin', 0.0)
+    if height is None:
+        if 'yheight' in params:
+            height = params['yheight']
+        else:
+            height = params.get('ymax', 0.0) - params.get('ymin', 0.0)
+    return _box(float(width), float(height), _APERTURE_THICKNESS)
+
+
+@DEFAULT_BREP_REGISTRY.register(NCrystalFilter)
+@DEFAULT_BREP_REGISTRY.register(Attenuator)
+def build_filter(_provenance, _instance, params: dict[str, float]):
+    return _box(_param(params, 'xwidth'), _param(params, 'yheight'), _param(params, 'zdepth'))
+
+
+@DEFAULT_BREP_REGISTRY.register(ESSource)
+def build_ess_source(_provenance, _instance, params: dict[str, float]):
+    height = _param(params, 'yheight')
+    width = params.get('focus_xw', height)
+    length = params.get('dist', height)
+    return _box(float(width), float(height), float(length))
+
+
+@DEFAULT_BREP_REGISTRY.register(RadialFilterCollimator)
+def build_radial_filter_collimator(_provenance, _instance, params: dict[str, float]):
+    bd = _bd()
+    height = _param(params, 'yheight')
+    angle = _param(params, 'angle_width')
+
+    shapes = []
+    for inner_key, outer_key in (
+            ('filter_minimum_radius', 'filter_maximum_radius'),
+            ('collimator_minimum_radius', 'collimator_maximum_radius'),
+    ):
+        inner = _param(params, inner_key)
+        outer = _param(params, outer_key)
+        if outer <= 0:
+            continue
+        outer_shape = bd.Cylinder(outer, height, arc_size=angle)
+        if inner > 0:
+            outer_shape = outer_shape - bd.Cylinder(inner, height + _APERTURE_THICKNESS, arc_size=angle)
+        shapes.append(outer_shape)
+
+    if not shapes:
+        return None
+    return bd.Compound(shapes)
+
+@DEFAULT_BREP_REGISTRY.register(Component)
+def build_arm(_provenance, _instance, params: dict[str, float]):
+    bd = _bd()
+    print(f'{_instance.name} arm')
+    width, length = 0.02, 0.2
+
+    ez = bd.extrude(bd.Circle(width / 2), length)
+    ex = bd.Plane(origin=(0,0,0), z_dir=(1,0,0)) * bd.extrude(bd.Circle(width / 2), length)
+    ey = bd.Plane(origin=(0,0,0), z_dir=(0,1,0)) * bd.extrude(bd.Circle(width / 2), length)
+    return bd.Compound(children=[ez, ex, ey], label=_instance.name)
+
+
+def instrument_to_assembly(instr, params: dict[str, float] | None = None, registry=None):
+    from mccode_antlr.display.instrument_display import InstrumentDisplay
+    from mccode_antlr.display.render.brep import instrument_to_assembly as upstream
+    from .registry import NiessBRepRegistry
+
+    instr_display = instr if isinstance(instr, InstrumentDisplay) else _SafeInstrumentDisplay(instr)
+    active_registry = DEFAULT_BREP_REGISTRY if registry is None else registry
+    if isinstance(active_registry, NiessBRepRegistry):
+        active_registry = active_registry.to_brep_registry(instr_display._instr)
+    return upstream(instr_display, params=params, registry=active_registry)
+
+
+def save_step(assembly_or_instr, path, params: dict[str, float] | None = None, registry=None):
+    from mccode_antlr.display.render.brep import save_step as upstream
+
+    assembly = assembly_or_instr
+    if hasattr(assembly_or_instr, 'components') or hasattr(assembly_or_instr, '_instr'):
+        assembly = instrument_to_assembly(assembly_or_instr, params=params, registry=registry)
+    return upstream(assembly, path)

--- a/src/niess/brep/provenance.py
+++ b/src/niess/brep/provenance.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+from typing import Any
+from dataclasses import dataclass
+
+from niess.mccode import read_niess_metadata
+
+
+@dataclass(frozen=True)
+class NiessProvenance:
+    namespace: str
+    schema_version: int
+    source_type: str
+    source_name: str
+    role: str
+    extra: dict[str, Any]
+
+    @classmethod
+    def from_instance(cls, instance) -> NiessProvenance | None:
+        payload = read_niess_metadata(instance)
+        if payload is None:
+            return None
+        return cls(
+            namespace=payload['namespace'],
+            schema_version=payload['schema_version'],
+            source_type=payload['source_type'],
+            source_name=payload['source_name'],
+            role=payload.get('role', 'physical-component'),
+            extra=payload.get('extra', {}),
+        )

--- a/src/niess/brep/registry.py
+++ b/src/niess/brep/registry.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+
+from typing import Any, Callable
+
+from niess.mccode import niess_source_type
+from .provenance import NiessProvenance
+
+_BRepBuilder = Callable[[NiessProvenance | None, Any, dict[str, float]], Any | None]
+
+
+class NiessBRepRegistry:
+    def __init__(self) -> None:
+        self._source_type_builders: dict[str, _BRepBuilder] = {}
+        self._role_builders: dict[str, _BRepBuilder] = {}
+        self._component_type_builders: dict[str, _BRepBuilder] = {}
+
+    def register(self, source: type | str):
+        source_type = source if isinstance(source, str) else niess_source_type(source)
+
+        def decorator(func: _BRepBuilder) -> _BRepBuilder:
+            self._source_type_builders[source_type] = func
+            return func
+
+        return decorator
+
+    def register_role(self, role: str):
+        def decorator(func: _BRepBuilder) -> _BRepBuilder:
+            self._role_builders[role] = func
+            return func
+
+        return decorator
+
+    def register_component_type(self, comp_type_name: str):
+        def decorator(func: _BRepBuilder) -> _BRepBuilder:
+            self._component_type_builders[comp_type_name] = func
+            return func
+
+        return decorator
+
+    def resolve_builder(self, instance) -> _BRepBuilder | None:
+        provenance = NiessProvenance.from_instance(instance)
+        if provenance is not None:
+            if provenance.source_type in self._source_type_builders:
+                return self._source_type_builders[provenance.source_type]
+            if provenance.role in self._role_builders:
+                return self._role_builders[provenance.role]
+
+        comp_type_name = getattr(instance.type, 'name', str(instance.type))
+        return self._component_type_builders.get(comp_type_name)
+
+    def build_shape(self, instance, params: dict[str, float] | None = None):
+        builder = self.resolve_builder(instance)
+        if builder is None:
+            return None
+        provenance = NiessProvenance.from_instance(instance)
+        return builder(provenance, instance, _merged_params(instance, params))
+
+    def to_brep_registry(self, instr):
+        from mccode_antlr.display.render.brep import BRepRegistry
+
+        registry = BRepRegistry()
+        comp_types = {getattr(instance.type, 'name', str(instance.type)) for instance in instr.components}
+        for comp_type in comp_types:
+            @registry.register(comp_type)
+            def wrapper(instance, params, _self=self):
+                return _self.build_shape(instance, params)
+        return registry
+
+
+DEFAULT_BREP_REGISTRY = NiessBRepRegistry()
+
+
+def _expr_float(value):
+    if isinstance(value, (int, float)):
+        return float(value)
+    simplified = value.simplify() if hasattr(value, 'simplify') else value
+    if hasattr(simplified, 'value') and isinstance(simplified.value, (int, float)):
+        return float(simplified.value)
+    return float(simplified)
+
+
+def _merged_params(instance, params: dict[str, float] | None = None):
+    merged = dict(params or {})
+    for component_parameter in instance.parameters:
+        try:
+            evaluated = component_parameter.value.evaluate(merged)
+            merged[component_parameter.name] = _expr_float(evaluated)
+        except Exception:
+            continue
+    return merged
+

--- a/src/niess/components/aperture.py
+++ b/src/niess/components/aperture.py
@@ -23,6 +23,12 @@ class Aperture(Component):
             height=height
         )
 
+    def __mccode_brep_extra__(self) -> dict[str, float]:
+        return {
+            'width': self.width.to(unit='m').value,
+            'height': self.height.to(unit='m').value,
+        }
+
 
 class Jaw(Aperture):
     """A special variable width aperture, open by default and configured at runtime"""
@@ -38,12 +44,13 @@ class Jaw(Aperture):
     def to_mccode(
             self, assembler: Assembler,
             at: Instance | str | None = None, rotate: Instance | str | None = None,
+            insert_brep_metadata: bool = False,
     ):
         from ..mccode import ensure_runtime_line as ensure
         half = self.width.to(unit='m').value / 2
         ensure(assembler, f'{self.name}_l/"m" = {-half}')
         ensure(assembler, f'{self.name}_r/"m" = {half}')
-        return super().to_mccode(assembler, at, rotate)
+        return super().to_mccode(assembler, at, rotate, insert_brep_metadata=insert_brep_metadata)
 
 
 class Slit(Aperture):
@@ -61,6 +68,7 @@ class Slit(Aperture):
     def to_mccode(
             self, assembler: Assembler,
             at: Instance | str | None = None, rotate: Instance | str | None = None,
+            insert_brep_metadata: bool = False,
     ):
         from ..mccode import ensure_runtime_line as ensure
         half = self.width.to(unit='m').value / 2
@@ -69,4 +77,4 @@ class Slit(Aperture):
         half = self.height.to(unit='m').value / 2
         ensure(assembler, f'{self.name}_b/"m" = {-half}')
         ensure(assembler, f'{self.name}_t/"m" = {half}')
-        return super().to_mccode(assembler, at, rotate)
+        return super().to_mccode(assembler, at, rotate, insert_brep_metadata=insert_brep_metadata)

--- a/src/niess/components/chopper.py
+++ b/src/niess/components/chopper.py
@@ -97,12 +97,13 @@ class DiscChopper(Chopper):
     def to_mccode(
             self, assembler: Assembler,
             at: Instance | str | None = None, rotate: Instance | str | None = None,
+            insert_brep_metadata: bool = False,
     ):
         from ..mccode import ensure_runtime_line as ensure
         ensure(assembler, f'{self.name}speed/"Hz" = {self.speed.value}')
         ensure(assembler, f'{self.name}phase/"degree" = {self.phase.to(unit="deg").value}')
         # the offset is handled by super's to_mccode -- no problems.
-        return super().to_mccode(assembler, at, rotate)
+        return super().to_mccode(assembler, at, rotate, insert_brep_metadata=insert_brep_metadata)
 
 
 class FermiChopper(Chopper):

--- a/src/niess/components/component.py
+++ b/src/niess/components/component.py
@@ -112,13 +112,20 @@ class Component(Base, kw_only=True):
         """Return the component type name and parameters needed to produce a McCode instance"""
         return 'Arm', {}
 
+    def __mccode_brep_role__(self) -> str:
+        return 'physical-component'
+
+    def __mccode_brep_extra__(self) -> dict[str, Any]:
+        return {}
+
     def to_mccode(
             self, assembler: Assembler,
             at: Instance | str | None = None, rotate: Instance | str | None = None,
+            insert_brep_metadata: bool = False,
     ):
         from mccode_antlr.common.parameters import InstrumentParameter as InstPar
         from ..spatial import mccode_ordered_angles
-        from ..mccode import ensure_runtime_parameter
+        from ..mccode import add_niess_metadata, ensure_runtime_parameter
 
         comp, pars = self.__mccode__()
 
@@ -136,4 +143,12 @@ class Component(Base, kw_only=True):
         at = (at.to(unit='m').value, at_rel)
         rot = (mccode_ordered_angles(self.orientation), rot_rel)
 
-        return assembler.component(self.name, comp, at=at, rotate=rot, parameters=pars)
+        instance = assembler.component(self.name, comp, at=at, rotate=rot, parameters=pars)
+        if insert_brep_metadata:
+            return add_niess_metadata(
+                instance,
+                self,
+                role=self.__mccode_brep_role__(),
+                extra=self.__mccode_brep_extra__(),
+            )
+        return instance

--- a/src/niess/components/filter.py
+++ b/src/niess/components/filter.py
@@ -104,11 +104,12 @@ class Attenuator(NCrystalFilter):
     def to_mccode(
             self, assembler: Assembler,
             at: Instance | str | None = None, rotate: Instance | str | None = None,
+            insert_brep_metadata: bool = False,
     ):
         from mccode_antlr.common import InstrumentParameter, Expr
         parameter = InstrumentParameter.parse(f"int {self.name}_in = 0")
         assembler.instrument.add_parameter(parameter, ignore_repeated=True)
-        comp = super().to_mccode(assembler, at, rotate)
+        comp = super().to_mccode(assembler, at, rotate, insert_brep_metadata=insert_brep_metadata)
         comp.WHEN(Expr.parameter(parameter.name))
         return comp
 
@@ -177,11 +178,12 @@ class RadialFilterCollimator(Filter):
     def to_mccode(
             self, assembler: Assembler,
             at: Instance | str | None = None, rotate: Instance | str | None = None,
+            insert_brep_metadata: bool = False,
     ):
         """Overload to ensure the registry we need is present"""
         from niess.mccode import ensure_registry
         ensure_registry(assembler, 'mcdotstar/mcstas-radial-filter-collimator@main')
-        comp = super().to_mccode(assembler, at, rotate)
+        comp = super().to_mccode(assembler, at, rotate, insert_brep_metadata=insert_brep_metadata)
         return comp
 
 

--- a/src/niess/components/guide.py
+++ b/src/niess/components/guide.py
@@ -334,9 +334,10 @@ class EllipticGuide(Guide):
     def to_mccode(
             self, assembler: Assembler,
             at: Instance | str | None = None, rotate: Instance | str | None = None,
+            insert_brep_metadata: bool = False,
     ):
         if isinstance(self.left, tuple):
             assembler.declare_array('double', f'{self.name}_lens', self.length.to(unit='m').values)
             for n in ('left', 'right', 'top', 'bottom'):
                 assembler.declare_array('double', f'{self.name}_{n}', getattr(self, n))
-        super().to_mccode(assembler, at, rotate)
+        return super().to_mccode(assembler, at, rotate, insert_brep_metadata=insert_brep_metadata)

--- a/src/niess/components/monitors.py
+++ b/src/niess/components/monitors.py
@@ -51,11 +51,12 @@ class FrameMonitor(Component):
     def to_mccode(
             self, assembler: Assembler,
             at: Instance | str | None = None, rotate: Instance | str | None = None,
+            insert_brep_metadata: bool = False,
     ):
         from niess.mccode import ensure_registry
         ensure_registry(assembler, 'mcdotstar/mcstas-frame-tof-monitor@main')
 
-        inst = super().to_mccode(assembler, at, rotate)
+        inst = super().to_mccode(assembler, at, rotate, insert_brep_metadata=insert_brep_metadata)
         # Build the NeXus Structure entry to point to the correct Kafka stream
         return add_monitor_metadata(assembler.name, inst, self.time_bins())
 

--- a/src/niess/components/source.py
+++ b/src/niess/components/source.py
@@ -109,11 +109,12 @@ class ESSource(Source):
     def to_mccode(
             self, assembler: Assembler,
             at: Instance | str | None = None, rotate: Instance | str | None = None,
+            insert_brep_metadata: bool = False,
     ):
         from ..mccode import ensure_runtime_parameter
         for field in self.fields():
             p = getattr(self, field)
             if isinstance(p, InstrumentParameter):
                 ensure_runtime_parameter(assembler, p)
-        return super().to_mccode(assembler, at, rotate)
+        return super().to_mccode(assembler, at, rotate, insert_brep_metadata=insert_brep_metadata)
 

--- a/src/niess/mccode.py
+++ b/src/niess/mccode.py
@@ -1,5 +1,17 @@
+from __future__ import annotations
+
+from json import dumps, loads
+from typing import Any
+
 from mccode_antlr.assembler import Assembler
 from mccode_antlr.common import InstrumentParameter
+from mccode_antlr.instr import Instance
+
+
+NIESS_BREP_METADATA_NAMESPACE = 'niess.brep'
+NIESS_BREP_METADATA_NAME = 'niess_brep'
+NIESS_BREP_METADATA_MIMETYPE = 'application/json'
+NIESS_BREP_METADATA_SCHEMA_VERSION = 1
 
 
 def ensure_user_var(a: Assembler, dtype: str, name: str, description: str):
@@ -80,3 +92,70 @@ def ensure_registry(a: Assembler, specification: str):
         raise RuntimeError(msg)
     if not reg in a.instrument.registries:
         a.instrument.registries += (reg,)
+
+
+def niess_source_type(source: type | Any) -> str:
+    typ = source if isinstance(source, type) else type(source)
+    return f'{typ.__module__}.{typ.__qualname__}'
+
+
+def niess_metadata_payload(
+        *,
+        source_type: str,
+        source_name: str,
+        role: str = 'physical-component',
+        extra: dict[str, Any] | None = None,
+):
+    return {
+        'namespace': NIESS_BREP_METADATA_NAMESPACE,
+        'schema_version': NIESS_BREP_METADATA_SCHEMA_VERSION,
+        'source_type': source_type,
+        'source_name': source_name,
+        'role': role,
+        'extra': {} if extra is None else extra,
+    }
+
+
+def add_niess_metadata(
+        instance: Instance,
+        source: Any | None = None,
+        *,
+        source_type: str | None = None,
+        source_name: str | None = None,
+        role: str = 'physical-component',
+        extra: dict[str, Any] | None = None,
+):
+    from mccode_antlr.common import MetaData
+
+    if source is not None:
+        source_type = niess_source_type(source)
+        source_name = getattr(source, 'name', None) if source_name is None else source_name
+
+    if source_type is None or source_name is None:
+        raise ValueError('Both source_type and source_name must be defined')
+
+    payload = niess_metadata_payload(
+        source_type=source_type,
+        source_name=source_name,
+        role=role,
+        extra=extra,
+    )
+    metadata = MetaData.from_instance_tokens(
+        instance.name,
+        NIESS_BREP_METADATA_MIMETYPE,
+        NIESS_BREP_METADATA_NAME,
+        dumps(payload, separators=(',', ':')),
+    )
+    instance.add_metadata(metadata)
+    return instance
+
+
+def read_niess_metadata(instance: Instance):
+    for metadata in reversed(instance.collect_metadata()):
+        if metadata.name != NIESS_BREP_METADATA_NAME:
+            continue
+        payload = loads(metadata.value)
+        if payload.get('namespace') != NIESS_BREP_METADATA_NAMESPACE:
+            continue
+        return payload
+    return None

--- a/tests/test_brep.py
+++ b/tests/test_brep.py
@@ -1,0 +1,141 @@
+from pytest import approx, importorskip
+
+
+def _origin():
+    import scipp as sc
+    return sc.vector([0.0, 0.0, 0.0], unit='m')
+
+
+def _identity():
+    import scipp as sc
+    return sc.spatial.rotation(value=[0.0, 0.0, 0.0, 1.0])
+
+
+def _assembly_child(assembly):
+    solids = assembly.solids()
+    assert len(solids) == 1
+    return solids[0]
+
+
+def test_to_mccode_adds_niess_metadata():
+    import scipp as sc
+    from mccode_antlr import Flavor
+    from mccode_antlr.assembler import Assembler
+    from niess.components import StraightGuide
+    from niess.mccode import read_niess_metadata
+
+    guide = StraightGuide(
+        name='g1',
+        position=_origin(),
+        orientation=_identity(),
+        length=sc.scalar(3.0, unit='m'),
+        left=1.0,
+        right=1.0,
+        top=1.0,
+        bottom=1.0,
+        width=sc.scalar(0.1, unit='m'),
+        height=sc.scalar(0.2, unit='m'),
+    )
+
+    assembler = Assembler('guide_test', flavor=Flavor.MCSTAS)
+    instance = guide.to_mccode(assembler, insert_brep_metadata=True)
+    payload = read_niess_metadata(instance)
+
+    assert payload is not None
+    assert payload['source_name'] == 'g1'
+    assert payload['source_type'].endswith('StraightGuide')
+    assert payload['role'] == 'physical-component'
+
+
+def test_straight_guide_brep_override():
+    importorskip('build123d')
+    import scipp as sc
+    from mccode_antlr import Flavor
+    from mccode_antlr.assembler import Assembler
+    from niess.brep import instrument_to_assembly
+    from niess.components import StraightGuide
+    from niess.mccode import add_niess_metadata
+
+    width, height, substrate = 0.1, 0.2, 0.02
+
+    guide = StraightGuide(
+        name='g1',
+        position=_origin(),
+        orientation=_identity(),
+        length=sc.scalar(3.0, unit='m'),
+        left=1.0,
+        right=1.0,
+        top=1.0,
+        bottom=1.0,
+        width=sc.scalar(width, unit='m'),
+        height=sc.scalar(height, unit='m'),
+    )
+
+    assembler = Assembler('guide_test', flavor=Flavor.MCSTAS)
+    mccode_guide = guide.to_mccode(assembler, insert_brep_metadata=True)
+    add_niess_metadata(mccode_guide, guide, extra={'substrate': substrate})
+
+    assembly = instrument_to_assembly(assembler.instrument)
+
+    child = _assembly_child(assembly)
+    size = child.bounding_box().size
+    assert size.X == approx(width + 2 * substrate)
+    assert size.Y == approx(height + 2 * substrate)
+    assert size.Z == approx(3.0)
+
+
+def test_slit_brep_override_uses_metadata_dimensions():
+    importorskip('build123d')
+    import scipp as sc
+    from mccode_antlr import Flavor
+    from mccode_antlr.assembler import Assembler
+    from niess.brep import instrument_to_assembly
+    from niess.components import Slit
+
+    slit = Slit(
+        name='slit1',
+        position=_origin(),
+        orientation=_identity(),
+        width=sc.scalar(0.05, unit='m'),
+        height=sc.scalar(0.03, unit='m'),
+    )
+
+    assembler = Assembler('slit_test', flavor=Flavor.MCSTAS)
+    slit.to_mccode(assembler, insert_brep_metadata=True)
+    assembly = instrument_to_assembly(assembler.instrument)
+
+    child = _assembly_child(assembly)
+    size = child.bounding_box().size
+    assert size.X == approx(0.05)
+    assert size.Y == approx(0.03)
+    assert size.Z > 0.0
+
+
+def test_filter_brep_override():
+    importorskip('build123d')
+    import scipp as sc
+    from mccode_antlr import Flavor
+    from mccode_antlr.assembler import Assembler
+    from niess.brep import instrument_to_assembly
+    from niess.components import NCrystalFilter
+
+    filt = NCrystalFilter(
+        name='f1',
+        position=_origin(),
+        orientation=_identity(),
+        width=sc.scalar(0.4, unit='m'),
+        height=sc.scalar(0.2, unit='m'),
+        length=sc.scalar(0.1, unit='m'),
+        composition='Al_sg225',
+        temperature=sc.scalar(300.0, unit='K'),
+    )
+
+    assembler = Assembler('filter_test', flavor=Flavor.MCSTAS)
+    filt.to_mccode(assembler, insert_brep_metadata=True)
+    assembly = instrument_to_assembly(assembler.instrument)
+
+    child = _assembly_child(assembly)
+    size = child.bounding_box().size
+    assert size.X == approx(0.4)
+    assert size.Y == approx(0.2)
+    assert size.Z == approx(0.1)


### PR DESCRIPTION
Some information about components is not needed/accepted by McStas, but would be useful to represent in a CAD version of the instrument.

This adds an optional `METADATA` key to every `McCode` component instance produced from `niess` components which can then be used to select _different_ McCode to `build123d`/`cadquery`/`OCCT` converters and/or provide extra information like, e.g., guide substrate thickness.

As a first draft, only a few components are provided with default overriding converters. More converters should be added to make this functionality more useful.