### PR TITLE
Use simple transmission-filter components

### DIFF
--- a/src/niess/components/filter.py
+++ b/src/niess/components/filter.py
@@ -83,7 +83,22 @@ class NCrystalFilter(Filter):
         params['yheight'] = self.height.to(unit='m').value
         params['zdepth'] = self.length.to(unit='m').value
         params['cfg'] = self.cfg
-        return 'NCrystal_sample', params
+        # TODO: Consider also setting (wavelength|energy|wavenumber) limits for
+        #       INITIALIZE calculated transmission data -- Filter_sample uses
+        #       wavelength and 'sensible' defaults without any specified.
+        return 'Filter_sample', params
+
+    def to_mccode(
+            self, assembler: Assembler,
+            at: Instance | str | None = None, rotate: Instance | str | None = None,
+            insert_brep_metadata: bool = False,
+    ):
+        """Overload to ensure the registry we need is present"""
+        from niess.mccode import ensure_registry
+        ensure_registry(assembler, 'mcdotstar/mcstas-radial-filter-collimator@main')
+        comp = super().to_mccode(assembler, at, rotate, insert_brep_metadata=insert_brep_metadata)
+        return comp
+
 
 
 class OrderedFilter(NCrystalFilter):
@@ -173,7 +188,10 @@ class RadialFilterCollimator(Filter):
             "collimation": self.collimation_angle.to(unit='deg').value,
             "cfg": self.cfg,
         }
-        return 'Radial_filter_collimator', params
+        # TODO: Consider also setting (wavelength|energy|wavenumber) limits for
+        #       INITIALIZE calculated transmission data -- Radial_col_filter uses
+        #       wavelength and 'sensible' defaults without any specified.
+        return 'Radial_col_filter', params
 
     def to_mccode(
             self, assembler: Assembler,


### PR DESCRIPTION
This pull request updates the McCode component integration for filter components in `src/niess/components/filter.py`. The main focus is on ensuring that new component names are used for McCode exports and that the necessary registry is present for radial filter collimators. Additionally, TODO comments have been added to highlight future improvements regarding wavelength or energy limits.

The newly chosen McStas components do not perform internal scattering-based simulations but instead assume straight-path transmission through a geometry, and apply a pre-cached transmission-probability reduction per ray.

**Component integration updates:**

* Changed the returned component name in `NCrystalFilter.__mccode__` from `'NCrystal_sample'` to `'Filter_sample'`, and added a TODO about setting wavelength/energy limits for transmission data.
* Changed the returned component name in `OrderedFilter.__mccode__` from `'Radial_filter_collimator'` to `'Radial_col_filter'`, and added a similar TODO for transmission data limits.

**Registry and code structure improvements:**

* Added an overloaded `to_mccode` method to `NCrystalFilter` to ensure the required registry for `'mcdotstar/mcstas-radial-filter-collimator@main'` is present before exporting the component.