### PR TITLE
Update mccode-antlr to version 0.21.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
   "scipp>=25.11.0",
   "numpy",
   "scipy",
-  "mccode-antlr>=0.20.0",
+  "mccode-antlr>=0.21.0",
   "mccode-to-kafka>=0.2.2",
   "msgspec>=0.20.0",
   "networkx>=3.6", # required for B4C_sg166_BoronCarbide


### PR DESCRIPTION
This pull request updates the `mccode-antlr` dependency version in the `pyproject.toml` file. The new version requirement is `>=0.21.0`, up from `>=0.20.0`. This ensures that the project uses the latest features and fixes from the `mccode-antlr` library.