### PR TITLE
Only simulate the wavelengths the choppers can pass

### DIFF
--- a/docs/examples/narrow_band.py
+++ b/docs/examples/narrow_band.py
@@ -1,0 +1,46 @@
+"""Narrow a source's wavelength band to what its chopper train can pass."""
+from pathlib import Path
+
+
+def main(outdir: Path) -> None:
+    # --8<-- [start:narrow]
+    from mccode_antlr import Flavor
+    from mccode_antlr.assembler import Assembler
+    from niess.chopcalc import narrow_source_wavelengths
+    from niess.teaching import Primary
+
+    assembler = Assembler('teaching', flavor=Flavor.MCSTAS)
+    Primary.from_calibration().to_mccode(assembler)
+
+    # once every component is in place, and before writing the instrument out
+    train = narrow_source_wavelengths(assembler)
+
+    print(f'narrowing {train.source.lambda_min}/{train.source.lambda_max} '
+          f'of {train.source.name!r}')
+    for chopper in train.choppers:
+        print(f'  {chopper.name:10s} {chopper.angle:>6s} deg opening, '
+              f'{chopper.path:>8.8s} m from the source')
+    # --8<-- [end:narrow]
+
+    # The band is computed at run time, so the row names parameters rather than numbers:
+    # change --chopperdelay on the command line and the band recomputes.
+    assert train.choppers[0].speed == 'chopperspeed'
+    assert train.choppers[0].delay == 'chopperdelay'
+
+    # The latest emission time comes from the source itself, not a hardcoded ESS pulse
+    assert train.source.latest_emission_note.startswith('tmax_multiplier')
+
+    text = str(assembler.instrument)
+    # the library, and the guard that stops an older one being used silently
+    assert '%include "chopper-lib"' in text
+    assert 'CHOPPER_LIB_VERSION < 20000' in text
+    # the narrowing writes through the source's own parameters
+    assert '&source_lambda_min, &source_lambda_max' in text
+    # and it is in the instrument's INITIALIZE, which runs before every component's
+    assert 'chopper_wavelength_limits' in text
+
+    (outdir / 'teaching_narrowed.instr').write_text(text)
+
+
+if __name__ == '__main__':
+    main(Path('.'))

--- a/docs/how-to/narrow-the-wavelength-band.md
+++ b/docs/how-to/narrow-the-wavelength-band.md
@@ -1,0 +1,98 @@
+# Narrow the wavelength band to what the choppers pass
+
+A source samples uniformly across the band it is given, and a chopper train throws most of
+that away. Every neutron absorbed at the first chopper cost something to create, so
+telling the source to only sample wavelengths that can reach the sample is free simulation
+speed.
+
+`niess.chopcalc` works that band out from the instrument itself.
+
+```python
+--8<-- "narrow_band.py:narrow"
+```
+
+Call it once the instrument is complete — after every section and every hand-added
+component, and before writing it out. It needs the top-level `Assembler`: a child from
+`assembler.included(...)` merges into its parent only when the block exits, so a section's
+own choppers are not visible from inside it.
+
+## Why this is C rather than Python
+
+The band depends on chopper speeds and delays, and those are run-time parameters — the
+whole point of emitting `chopperspeed` and `chopperdelay` rather than numbers. So the
+calculation cannot happen when the instrument is built. `chopcalc` emits a call to
+[chopper-lib](https://github.com/mcdotstar/mcstas-chopper-lib) into the instrument's
+`INITIALIZE` instead, which McCode runs *before* every component's own initialisation.
+The source therefore reads the narrowed values, and
+
+```shell
+./teaching -n 1e7 chopperdelay=0.006
+```
+
+recomputes the band without rebuilding anything. The instrument says what it did:
+
+```
+niess.chopcalc: sampling 0.5 to 2.51491 AA instead of 0.5 to 10 AA.
+```
+
+## What it needs from the source
+
+The wavelength limits have to be **instrument parameters**, because the generated C writes
+through their addresses. In a niess calibration that means giving them as parameter
+specifications rather than values:
+
+```python
+'wavelength_minimum': 'source_lambda_min/"angstrom" = 0.75',
+'wavelength_maximum': 'source_lambda_max/"angstrom" = 30.0',
+```
+
+A literal is refused, with that fix in the message.
+
+The source is found from the beam path — it is the one component neutrons enter at, so it
+is a root of the particle flow graph. That matters because a wavelength monitor is not a
+source but looks like one: `L_monitor`, `TOFLambda_monitor`, `DivLambda_monitor`,
+`PolLambda_monitor` and `MeanPolLambda_monitor` all take `Lmin` and `Lmax`. Pass
+`source='...'` when an instrument has more than one entry point.
+
+## What it leaves out, and why that is safe
+
+Leaving a chopper out of the calculation can only make the band **wider**, never narrower,
+so it never discards a neutron that would have passed. That is what makes the following
+conservative rather than wrong:
+
+| left out | because |
+| --- | --- |
+| a disc in a McStas `GROUP` with no niess provenance | grouped discs are alternatives, not a series, and there is nothing to reconstruct an envelope from |
+| a Fermi chopper | chopper-lib's `chopper_parameters` cannot describe one |
+| a disc whose speed, opening or delay is unset | there is no row to write |
+
+A **multi-slit disc** is not left out but approximated. chopper-lib intersects chopper
+acceptances, while a disc's openings are alternatives — so one row per opening would demand
+a neutron clear every opening at once, giving a band too narrow, which is the one failure
+that loses neutrons. `chopcalc` uses the disc's angular envelope instead, spanning its
+first opening's edge to its last. That admits the gaps between openings too, so the band
+comes out wider than the disc really passes, and it warns every time:
+
+```
+niess.chopcalc: multi-opening disc 'pack' (pack_slit_0, pack_slit_1) is modelled as its
+50 degree angular envelope, ... Revisit when chopper-lib grows a
+multi_chopper_inverse_velocity_limits.
+```
+
+A disc whose openings span a full revolution constrains nothing and is dropped outright.
+
+One case stops the calculation altogether rather than approximating it: a chopper with
+`isfirst=1` re-times neutrons instead of absorbing them, so every downstream delay is
+measured from a different zero and the chopper-train model does not apply.
+
+## Flight paths
+
+Path lengths are walked along the beam — `Instr.build_flow_graph()`, then the summed
+segments from the source — rather than measured straight, so a curved guide is followed
+instead of cut across. A chopper's emitted `AT` is already the point where the beam crosses
+its disc, which is what a niess `offset` converts to, so no further correction is needed.
+
+If the beam has to turn sharply to arrive at a component, `chopcalc` says so: that usually
+means the component is placed at its spindle rather than on the beam, which would also make
+it absorb every neutron at run time. `path_lengths={'chopper': 15.02}` overrides a measured
+path when the real one is known by other means.

--- a/src/niess/chopcalc/__init__.py
+++ b/src/niess/chopcalc/__init__.py
@@ -1,0 +1,123 @@
+"""Only simulate the wavelengths a chopper train can actually pass.
+
+A source samples uniformly across the band it is given, and a chopper train throws most of
+that away. Narrowing the source's own ``Lmin``/``Lmax`` to the band the train passes is
+free simulation speed: every neutron that would have been absorbed at the first chopper is
+never created.
+
+The band cannot be worked out when the instrument is built, because it depends on chopper
+speeds and delays that are run-time parameters. So this emits C instead, calling
+chopper-lib from the instrument's INITIALIZE -- which McCode runs before every component's
+own initialisation, so the source reads the narrowed values.
+
+    primary.to_mccode(assembler)
+    narrow_source_wavelengths(assembler)
+"""
+from __future__ import annotations
+
+import logging
+
+from .discovery import ChopcalcError, build_train
+from .emit import (CHOPPER_LIB_REGISTRY, already_emitted, declare_text,
+                   include_present, initialize_text)
+from .model import ChopperEntry, ChopperTrain, Exclusion, SourceEntry
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    'ChopcalcError',
+    'ChopperEntry',
+    'ChopperTrain',
+    'Exclusion',
+    'SourceEntry',
+    'narrow_source_wavelengths',
+]
+
+
+def narrow_source_wavelengths(
+        assembler,
+        *,
+        source: str | None = None,
+        skip=(),
+        path_lengths=None,
+        latest_emission: float | None = None,
+        registry: str = CHOPPER_LIB_REGISTRY,
+        strict: bool = False,
+) -> ChopperTrain | None:
+    """Restrict the source's wavelength band to what the chopper train passes.
+
+    Call it once the instrument is complete -- after every section and every hand-added
+    component, before writing the instrument out.
+
+    Parameters
+    ----------
+    assembler:
+        The **top-level** assembler. A child from ``assembler.included(...)`` merges into
+        its parent only when the block exits, so its choppers are not visible yet.
+    source:
+        The source component's name. Inferred from the beam path when omitted.
+    skip:
+        Chopper names to leave out deliberately. Leaving a chopper out only widens the
+        band, so it is always safe.
+    path_lengths:
+        Flight paths in metres, by chopper name, overriding the measured ones.
+    latest_emission:
+        Seconds after t=0 that the source can still emit. Taken from the source when it
+        says (``tmax_multiplier``); a longer time widens the band, which is the safe
+        direction.
+    strict:
+        Raise :class:`ChopcalcError` instead of warning and doing nothing.
+
+    Returns
+    -------
+    The train that was used, or ``None`` when nothing could be narrowed.
+    """
+    from ..mccode import ensure_registry
+
+    if getattr(assembler, 'parent', None) is not None:
+        raise ChopcalcError(
+            'narrow_source_wavelengths needs the top-level Assembler, after every '
+            'section has been added. A section\'s child Assembler is merged into its '
+            'parent only on leaving the included() block, so its components -- and '
+            'every later section\'s -- are not visible yet.'
+        )
+
+    instrument = assembler.instrument
+    if already_emitted(instrument):
+        return _refuse('this instrument has already been narrowed; calling '
+                       'narrow_source_wavelengths twice would apply two bands', strict)
+
+    try:
+        train = build_train(instrument, source=source, skip=skip,
+                            path_lengths=path_lengths, latest_emission=latest_emission)
+    except ChopcalcError as error:
+        return _refuse(str(error), strict)
+
+    for exclusion in train.excluded:
+        logger.warning('niess.chopcalc: leaving out %s -- %s',
+                       ', '.join(exclusion.members), exclusion.reason)
+
+    if not train.choppers:
+        why = '; '.join(f'{e.name}: {e.reason}' for e in train.excluded)
+        return _refuse(
+            f'no chopper reached the calculation, so there is nothing to narrow'
+            f'{" -- " + why if why else ""}', strict)
+
+    ensure_registry(assembler, registry)
+    if not include_present(instrument):
+        assembler.declare(declare_text())
+    assembler.initialize(initialize_text(train))
+    logger.info(
+        'niess.chopcalc: %d chopper(s) narrowing %s/%s of source %r',
+        len(train.choppers), train.source.lambda_min, train.source.lambda_max,
+        train.source.name,
+    )
+    return train
+
+
+def _refuse(message: str, strict: bool) -> None:
+    """Emitting nothing is always safe -- the instrument samples the band it was given."""
+    if strict:
+        raise ChopcalcError(message)
+    logger.warning('niess.chopcalc: %s', message)
+    return None

--- a/src/niess/chopcalc/discovery.py
+++ b/src/niess/chopcalc/discovery.py
@@ -1,0 +1,407 @@
+"""Read an assembled instrument: which source, which choppers, how far apart.
+
+Everything here comes off the emitted components. Nothing is re-derived from a niess
+calibration or from a parameter-naming convention, so an instrument niess did not build
+works the same way.
+"""
+from __future__ import annotations
+
+import logging
+from math import acos, degrees, dist, fabs
+
+from ..dispatch import component_type_name, expr_float
+from ..provenance import NiessProvenance
+from .model import ChopperEntry, Exclusion, SourceEntry
+
+logger = logging.getLogger(__name__)
+
+CHOPPER_COMPONENT_TYPE = 'DiskChopper'
+UNSUPPORTED_CHOPPER_TYPES = frozenset({
+    'FermiChopper', 'FermiChopper_ILL', 'Vitess_ChopperFermi', 'Fermi_chop2a',
+})
+ESS_SOURCE_DURATION = 2.857e-3  # seconds; matches niess.components.source
+DEFAULT_LATEST_EMISSION = 3 * ESS_SOURCE_DURATION
+MULTI_SLIT_SOURCE_TYPE = 'MultiSlitChopper'
+OFF_BEAM_TURN = 1.0  # degrees the beam may bend on arrival before it looks like a detour
+
+
+class ChopcalcError(RuntimeError):
+    """The band could not be worked out, and the reason is worth acting on."""
+
+
+def _parameter(instance, name):
+    """A parameter's value expression, or None when the component has no such parameter."""
+    parameter = instance.get_parameter(name)
+    return None if parameter is None else parameter.value
+
+
+def _as_float(value, default=None):
+    try:
+        return expr_float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _identifier(value) -> str | None:
+    """The name, when ``value`` is a bare symbol rather than a number or an expression."""
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text if text.isidentifier() else None
+
+
+def _c_double(value: float) -> str:
+    """A float that still looks like a double once printed."""
+    text = f'{float(value):.12g}'
+    return text if any(c in text for c in '.e') else text + '.0'
+
+
+# -- the source ---------------------------------------------------------------
+
+def find_source(instrument, graph, name: str | None = None):
+    """The component neutrons come from.
+
+    Not the one with the right parameters -- ``L_monitor``, ``TOFLambda_monitor``,
+    ``DivLambda_monitor``, ``PolLambda_monitor`` and ``MeanPolLambda_monitor`` all take
+    ``Lmin`` and ``Lmax``, so a wavelength monitor would answer to that. Not the one with
+    the right category either: ``get_component_names_by_category('sources')`` is empty for
+    an instrument built this way. The beam path is what distinguishes them -- neutrons
+    enter at the source, so it is a root of the particle flow graph and a monitor is not.
+    """
+    if name is not None:
+        try:
+            instance = instrument.get_component(name)
+        except RuntimeError:
+            instance = None
+        if instance is None:
+            raise ChopcalcError(
+                f'no component named {name!r}; source= must name one of the '
+                f'instrument\'s components'
+            )
+        return instance
+
+    roots = [n for n in graph.nodes if graph.in_degree(n) == 0]
+    if len(roots) != 1:
+        raise ChopcalcError(
+            f'the beam path has {len(roots)} roots ({", ".join(sorted(roots)) or "none"}), '
+            f'so the source is ambiguous; name it with source='
+        )
+    return instrument.get_component(roots[0])
+
+
+def source_entry(instrument, instance, latest_emission: float | None) -> SourceEntry:
+    """Verify the source can be narrowed, and read what the narrowing needs."""
+    names = {}
+    for which in ('Lmin', 'Lmax'):
+        value = _parameter(instance, which)
+        if value is None:
+            raise ChopcalcError(
+                f'source {instance.name!r} ({component_type_name(instance)}) has no '
+                f'{which}, so there is no wavelength band to narrow'
+            )
+        identifier = _identifier(value)
+        if identifier is None:
+            raise ChopcalcError(
+                f'source {instance.name!r} has {which}={value}, which is not an '
+                f'instrument parameter. chopcalc narrows the band by writing through '
+                f'&{which} at run time, and &{value} is not valid C. Give the source a '
+                f'parameter instead -- in niess, '
+                f'\'wavelength_minimum\': \'source_lambda_min/"angstrom" = 0.75\' in the '
+                f'calibration.'
+            )
+        if instrument.get_parameter(identifier) is None:
+            raise ChopcalcError(
+                f'source {instance.name!r} has {which}={identifier}, which is not a '
+                f'DEFINE INSTRUMENT parameter. Only those expand to an lvalue that '
+                f'exists before init() runs, which is what chopcalc writes through.'
+            )
+        names[which] = identifier
+
+    if latest_emission is not None:
+        emission, note = _c_double(latest_emission), 'given to narrow_source_wavelengths'
+    else:
+        multiplier = _as_float(_parameter(instance, 'tmax_multiplier'))
+        if multiplier is None:
+            emission = _c_double(DEFAULT_LATEST_EMISSION)
+            note = f'default, {DEFAULT_LATEST_EMISSION / ESS_SOURCE_DURATION:g} ESS pulses'
+            logger.warning(
+                'niess.chopcalc: source %r (%s) has no tmax_multiplier, so the latest '
+                'emission time is unknown. Using %s s. Pass latest_emission= to set it; '
+                'a longer time widens the band, which is the safe direction.',
+                instance.name, component_type_name(instance), emission,
+            )
+        else:
+            emission = f'{_c_double(multiplier)} * {ESS_SOURCE_DURATION:g}'
+            note = 'tmax_multiplier * ESS_SOURCE_DURATION'
+
+    return SourceEntry(
+        name=instance.name,
+        lambda_min=names['Lmin'],
+        lambda_max=names['Lmax'],
+        latest_emission=emission,
+        latest_emission_note=note,
+    )
+
+
+# -- geometry -----------------------------------------------------------------
+
+def positions(instrument) -> dict[str, tuple[float, float, float]]:
+    """Every component's absolute position, reduced to numbers."""
+    resolved = {}
+    for name, orient in instrument.resolve_orientations().items():
+        place = orient.position()
+        try:
+            resolved[name] = tuple(
+                expr_float(c) for c in (place.x, place.y, place.z)
+            )
+        except (TypeError, ValueError, AttributeError):
+            continue  # depends on a run-time parameter; the caller excludes it
+    return resolved
+
+
+def beam_path_length(graph, places, source: str, chopper: str) -> float:
+    """How far a neutron travels from the source to the chopper, in metres.
+
+    Walked along the particle flow graph rather than measured straight, so a curved guide
+    is followed instead of chorded. A chopper's emitted position is already the point
+    where the beam crosses its disc -- that is what niess' ``offset`` converts to -- so
+    the endpoints need no correction.
+    """
+    from networkx import shortest_path
+
+    route = shortest_path(graph, source, chopper)
+    missing = [n for n in route if n not in places]
+    if missing:
+        raise ChopcalcError(
+            f'the beam path from {source!r} to {chopper!r} passes {missing[0]!r}, whose '
+            f'position depends on a run-time parameter and cannot be measured'
+        )
+    walked = sum(dist(places[u], places[v]) for u, v in zip(route, route[1:]))
+
+    turn = _arrival_turn(places, route)
+    if turn is not None and turn > OFF_BEAM_TURN:
+        logger.warning(
+            'niess.chopcalc: the beam turns %.2f degrees to arrive at %r, so its flight '
+            'path of %.4f m probably includes a detour. A DiskChopper AT must be where '
+            'the beam crosses the disc, not at the spindle -- check that the '
+            'calibration subtracts its offset. Pass path_lengths={%r: ...} to override.',
+            turn, chopper, walked, chopper,
+        )
+    return walked
+
+
+def _arrival_turn(places, route) -> float | None:
+    """How sharply the beam turns at the last step, in degrees.
+
+    A component that is not on the beam is reached by a detour, and a detour bends the
+    path. Guide curvature does not: it is spread along the guide segments, so every
+    BIFROST chopper measures 0.0000 degrees here while a disc placed at its spindle
+    rather than at the beam measures several.
+    """
+    if len(route) < 3:
+        return None
+    before, at, after = (places[n] for n in route[-3:])
+    first = [b - a for a, b in zip(before, at)]
+    second = [b - a for a, b in zip(at, after)]
+    lengths = dist((0, 0, 0), first) * dist((0, 0, 0), second)
+    if lengths == 0:
+        return None
+    cosine = sum(x * y for x, y in zip(first, second)) / lengths
+    return degrees(acos(max(-1.0, min(1.0, cosine))))
+
+
+# -- the choppers -------------------------------------------------------------
+
+def _speed_expression(instance) -> str:
+    """``nu``, or ``nu`` times ``nslit`` for equal, evenly spaced openings.
+
+    chopper-lib's header documents that substitution: a disc with ``nslit`` identical
+    openings presents them at ``nslit`` times its rotation frequency, and a delay means
+    the same thing either way. The sign of ``nu`` is untouched, so direction survives.
+    """
+    nu = _parameter(instance, 'nu')
+    nslit = _as_float(_parameter(instance, 'nslit'), 1.0)
+    if nslit is None or nslit == 1.0:
+        return str(nu)
+    return f'({nu}) * {_c_double(nslit)}'
+
+
+def _delay_expression(instance) -> str:
+    """``delay``, unless a ``phase`` is set -- the branch DiskChopper itself takes."""
+    delay = _parameter(instance, 'delay')
+    phase = _parameter(instance, 'phase')
+    literal_phase = _as_float(phase)
+    if phase is None or literal_phase == 0.0:
+        return str(delay)
+    nu = _parameter(instance, 'nu')
+    if literal_phase is not None:
+        return f'({phase}) / (360.0 * fabs({nu}))'
+    # a run-time phase: mirror DiskChopper's own `if (phase)` so the two never disagree
+    return f'(({phase}) != 0 ? ({phase}) / (360.0 * fabs({nu})) : ({delay}))'
+
+
+def _envelope(group, places, path: float) -> tuple[ChopperEntry | None, Exclusion | None]:
+    """One conservative row for a multi-opening disc, from its provenance.
+
+    A disc's true acceptance is the *union* of its openings, and chopper-lib intersects
+    chopper acceptances -- so a row per opening would demand a neutron clear every one at
+    once, giving a band too narrow, the one failure that loses neutrons. The angular
+    envelope admits everything the disc admits plus the gaps between openings, so the
+    band can only come out too wide.
+    """
+    name = group[0][1].extra['nexus_group_id']
+    members = tuple(instance.name for instance, _ in group)
+
+    edges = [e for _, provenance in group for e in provenance.extra['slit_edges']]
+    width = max(edges) - min(edges)
+    centre = (max(edges) + min(edges)) / 2
+    beam = float(group[0][1].extra.get('beam_position', 0.0))
+    delay_parameter = group[0][1].extra['delay_parameter']
+    speed = str(_parameter(group[0][0], 'nu'))
+
+    logger.warning(
+        'niess.chopcalc: multi-opening disc %r (%s) is modelled as its %g degree '
+        'angular envelope, which admits the gaps between its openings too, so the band '
+        'comes out wider than the disc really passes. Revisit when chopper-lib grows a '
+        'multi_chopper_inverse_velocity_limits.',
+        name, ', '.join(members), width,
+    )
+    if width >= 360.0:
+        return None, Exclusion(
+            name=name, members=members,
+            reason=f'its openings span {width:g} degrees, a full revolution, so the '
+                   f'envelope constrains nothing',
+        )
+
+    turn = (beam - centre) % 360.0
+    delay = (
+        f'{delay_parameter}' if turn == 0 else
+        f'{delay_parameter} + ({speed} < 0 ? {_c_double(360.0 - turn)} : '
+        f'{_c_double(turn)}) / (360.0 * fabs({speed}))'
+    )
+    return ChopperEntry(
+        name=name, speed=speed, delay=delay,
+        angle=_c_double(width), path=_c_double(path),
+        note=f'{width:g} degree envelope of {len(members)} openings',
+    ), None
+
+
+def _check_group(group) -> None:
+    """A group whose metadata disagrees with its components cannot be trusted.
+
+    Stale metadata could make the band too narrow, which is the failure that loses
+    neutrons, so this raises rather than guessing.
+    """
+    name = group[0][1].extra['nexus_group_id']
+    speeds = {str(_parameter(i, 'nu')) for i, _ in group}
+    delays = {p.extra.get('delay_parameter') for _, p in group}
+    if len(speeds) != 1:
+        raise ChopcalcError(
+            f'disc {name!r} has openings turning at different speeds ({sorted(speeds)}); '
+            f'its provenance no longer matches the instrument'
+        )
+    if len(delays) != 1:
+        raise ChopcalcError(
+            f'disc {name!r} has openings with different delay parameters '
+            f'({sorted(str(d) for d in delays)}); its provenance no longer matches the '
+            f'instrument'
+        )
+    for instance, provenance in group:
+        edges = provenance.extra['slit_edges']
+        theta = _as_float(_parameter(instance, 'theta_0'))
+        if theta is None or fabs(theta - (edges[1] - edges[0])) > 1e-9:
+            raise ChopcalcError(
+                f'opening {instance.name!r} of disc {name!r} is {theta} degrees wide but '
+                f'its provenance says {edges[1] - edges[0]}; the instrument was edited '
+                f'after niess emitted it'
+            )
+
+
+def build_train(instrument, *, source=None, skip=(), path_lengths=None,
+                latest_emission=None):
+    """Everything the calculation needs, read off the assembled instrument."""
+    from .model import ChopperTrain
+
+    graph = instrument.build_flow_graph()
+    places = positions(instrument)
+    overrides = dict(path_lengths or {})
+    skip = set(skip)
+
+    source_instance = find_source(instrument, graph, source)
+    entry = source_entry(instrument, source_instance, latest_emission)
+
+    singles, groups, excluded = [], {}, []
+    for instance in instrument.components:
+        type_name = component_type_name(instance)
+        if type_name in UNSUPPORTED_CHOPPER_TYPES:
+            excluded.append(Exclusion(
+                instance.name, (instance.name,),
+                f'{type_name} cannot be described by a chopper_parameters row'))
+            continue
+        if type_name != CHOPPER_COMPONENT_TYPE:
+            continue
+        if instance.name in skip:
+            excluded.append(Exclusion(instance.name, (instance.name,), 'skipped by the caller'))
+            continue
+
+        if _as_float(_parameter(instance, 'isfirst'), 0.0):
+            raise ChopcalcError(
+                f'chopper {instance.name!r} has isfirst=1, so it re-times neutrons '
+                f'rather than absorbing them and every downstream delay is measured '
+                f'from a different zero. The chopper-train model does not apply.'
+            )
+
+        provenance = NiessProvenance.from_instance(instance)
+        if provenance is not None and provenance.source_type.endswith(MULTI_SLIT_SOURCE_TYPE):
+            groups.setdefault(provenance.extra['nexus_group_id'], []).append(
+                (instance, provenance))
+            continue
+        if instance.group:
+            excluded.append(Exclusion(
+                instance.name, (instance.name,),
+                f'it is in McStas GROUP {instance.group!r}, whose members are '
+                f'alternatives rather than a series, and it carries no slit_edges to '
+                f'build an envelope from'))
+            continue
+        if any(_parameter(instance, p) is None for p in ('nu', 'theta_0', 'delay')):
+            excluded.append(Exclusion(
+                instance.name, (instance.name,), 'nu, theta_0 or delay is unset'))
+            continue
+        singles.append(instance)
+
+    rows = []
+    for instance in singles:
+        path = overrides.pop(instance.name, None)
+        if path is None:
+            try:
+                path = beam_path_length(graph, places, entry.name, instance.name)
+            except ChopcalcError as error:
+                excluded.append(Exclusion(instance.name, (instance.name,), str(error)))
+                continue
+        rows.append(ChopperEntry(
+            name=instance.name,
+            speed=_speed_expression(instance),
+            delay=_delay_expression(instance),
+            angle=_c_double(_as_float(_parameter(instance, 'theta_0'))),
+            path=_c_double(path),
+        ))
+
+    for name, group in groups.items():
+        _check_group(group)
+        group.sort(key=lambda pair: pair[1].extra.get('nexus_group_index', 0))
+        path = overrides.pop(name, None)
+        if path is None:
+            path = beam_path_length(graph, places, entry.name, group[0][0].name)
+        row, exclusion = _envelope(group, places, path)
+        (rows if row is not None else excluded).append(row or exclusion)
+
+    if overrides:
+        raise ChopcalcError(
+            f'path_lengths names {sorted(overrides)}, which are not choppers in this '
+            f'instrument'
+        )
+
+    # beam order, which is the order the neutron meets them
+    order = {c.name: i for i, c in enumerate(instrument.components)}
+    rows.sort(key=lambda row: order.get(row.name, len(order)))
+    return ChopperTrain(source=entry, choppers=tuple(rows), excluded=tuple(excluded))

--- a/src/niess/chopcalc/emit.py
+++ b/src/niess/chopcalc/emit.py
@@ -1,0 +1,108 @@
+"""Turn a discovered chopper train into C. Nothing here reads the instrument."""
+from __future__ import annotations
+
+from textwrap import indent
+
+from .model import ChopperTrain
+
+CHOPPER_LIB_REGISTRY = 'mcdotstar/mcstas-chopper-lib@v2.0.0'
+CHOPPER_LIB_MINIMUM_VERSION = 20000
+INCLUDE_MARKER = '%include "chopper-lib"'
+ARRAY_MARKER = 'chopcalc_choppers'
+
+DECLARE_TEXT = f'''
+/* niess.chopcalc: chopper-lib, for narrowing the source wavelength band */
+{INCLUDE_MARKER}
+#if !defined(CHOPPER_LIB_VERSION) || CHOPPER_LIB_VERSION < {CHOPPER_LIB_MINIMUM_VERSION}
+#error "niess.chopcalc sets chopper delays in seconds; chopper-lib 2.0.0 or newer is required"
+#endif
+'''
+
+
+def declare_text() -> str:
+    """The library include, and the guard that stops an older one being used silently.
+
+    The struct layout did not change when chopper-lib's second field went from a phase in
+    degrees to a delay in seconds, so without the guard a 1.x library compiles cleanly and
+    computes a different band.
+    """
+    return DECLARE_TEXT
+
+
+def initialize_text(train: ChopperTrain) -> str:
+    """The whole calculation, as one braced compound statement.
+
+    Braced so the array is scoped and ``chopcalc_*`` cannot collide with anything else in
+    INITIALIZE. The array is a local with run-time initialisers -- legal for automatic
+    storage, and what lets a row name an instrument parameter.
+    """
+    source = train.source
+    rows = ',\n'.join(
+        f'  {{{c.speed}, {c.delay}, {c.angle}, {c.path}}}'
+        f' /* {c.name}{"" if c.note is None else " -- " + c.note} */'
+        for c in train.choppers
+    )
+
+    notes = [
+        f'{len(train.choppers)} chopper{"" if len(train.choppers) == 1 else "s"} '
+        f'considered, path lengths walked along the beam from {source.name!r}.',
+    ]
+    approximate = [c for c in train.choppers if c.note]
+    for chopper in approximate:
+        notes.append(f'{chopper.name}: {chopper.note} -- the band comes out wider '
+                     f'than this disc really passes.')
+    for exclusion in train.excluded:
+        notes.append(f'{exclusion.name}: left out, {exclusion.reason}.')
+
+    body = f'''
+/* niess.chopcalc: narrow {source.lambda_min}/{source.lambda_max} to the band the chopper
+ * train can pass, so the source only samples wavelengths that can reach the sample.
+ * Instrument INITIALIZE runs before every _setpos and every component _initialize, so
+ * {source.name!r} reads the narrowed values.
+{indent(chr(10).join(" * " + n for n in notes), "")}
+ */
+{{
+  chopper_parameters {ARRAY_MARKER}[] = {{
+{rows}
+  }};
+  double chopcalc_latest = {source.latest_emission}; /* {source.latest_emission_note}, s */
+  double chopcalc_min = {source.lambda_min}, chopcalc_max = {source.lambda_max};
+  unsigned chopcalc_windows = chopper_wavelength_limits(
+    &{source.lambda_min}, &{source.lambda_max},
+    sizeof({ARRAY_MARKER}) / sizeof(chopper_parameters), {ARRAY_MARKER},
+    chopcalc_min, chopcalc_max, chopcalc_latest);
+  if (chopcalc_windows == 0 || !({source.lambda_max} > {source.lambda_min})
+      || {source.lambda_min} <= 0) {{
+    /* chopper_wavelength_limits leaves its outputs alone when it finds nothing; putting
+     * the band back makes that a property of this instrument rather than of whichever
+     * library version was resolved. It also keeps a degenerate band away from
+     * ESS_butterfly, whose own INITIALIZE exits when Lmin >= Lmax. */
+    {source.lambda_min} = chopcalc_min;
+    {source.lambda_max} = chopcalc_max;
+    MPI_MASTER(printf(
+      "niess.chopcalc: no usable band between %g and %g AA -- sampling unchanged.\\n"
+      "niess.chopcalc: check the chopper speeds and delays; a delay is a time in "
+      "seconds, and the sign of a speed sets the direction of rotation.\\n",
+      chopcalc_min, chopcalc_max););
+  }} else {{
+    if (chopcalc_windows > 1) {{
+      MPI_MASTER(printf(
+        "niess.chopcalc: %u separate bands between %g and %g AA; their envelope is "
+        "used, so wavelengths they block are still sampled.\\n",
+        chopcalc_windows, chopcalc_min, chopcalc_max););
+    }}
+    MPI_MASTER(printf("niess.chopcalc: sampling %g to %g AA instead of %g to %g AA.\\n",
+      {source.lambda_min}, {source.lambda_max}, chopcalc_min, chopcalc_max););
+  }}
+}}
+'''
+    return body
+
+
+def already_emitted(instrument) -> bool:
+    """Has a previous call already narrowed this instrument?"""
+    return any(ARRAY_MARKER in str(block) for block in instrument.initialize)
+
+
+def include_present(instrument) -> bool:
+    return any(INCLUDE_MARKER in str(block) for block in instrument.declare)

--- a/src/niess/chopcalc/model.py
+++ b/src/niess/chopcalc/model.py
@@ -1,0 +1,63 @@
+"""What discovery hands to emission.
+
+Every field of a :class:`ChopperEntry` is C *text*, not a number. The array it becomes is
+a local in ``init()``, so a field may name a run-time instrument parameter -- which is the
+point: change a chopper speed on the command line and the band recomputes without a
+rebuild.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ChopperEntry:
+    """One row of the generated ``chopper_parameters`` array."""
+
+    name: str
+    """The instance name, or the disc's group id when this row is an envelope."""
+    speed: str
+    """Hz. The sign sets the direction of rotation, and is preserved."""
+    delay: str
+    """Seconds, when an opening's centre is on the path."""
+    angle: str
+    """Degrees. **One** opening -- chopper-lib has no notion of several."""
+    path: str
+    """Metres travelled from the source, along the beam."""
+    note: str | None = None
+    """Why this row is approximate, when it is."""
+
+
+@dataclass(frozen=True)
+class SourceEntry:
+    """The source, and the two parameters this narrows."""
+
+    name: str
+    lambda_min: str
+    """An instrument-parameter name. It has to be one: the C writes through its address."""
+    lambda_max: str
+    latest_emission: str
+    """Seconds, as a C expression, so the arithmetic stays visible in the instrument."""
+    latest_emission_note: str
+    """Where that expression came from, for the generated comment."""
+
+
+@dataclass(frozen=True)
+class Exclusion:
+    """A chopper the calculation left out, and why."""
+
+    name: str
+    members: tuple[str, ...]
+    reason: str
+
+
+@dataclass(frozen=True)
+class ChopperTrain:
+    """Everything the calculation found.
+
+    Returned so a build script can assert on what was used without reading generated C.
+    """
+
+    source: SourceEntry
+    choppers: tuple[ChopperEntry, ...]
+    excluded: tuple[Exclusion, ...]

--- a/src/niess/components/chopper.py
+++ b/src/niess/components/chopper.py
@@ -33,7 +33,12 @@ class DiscChopper(Chopper):
         return dot(vector(value=[0, 0, 1.]), self.velocity).to(unit='Hz')
 
     def chopper_lib_parameters(self):
-        """Useful for specifying elements of a vector used by chopper-lib"""
+        """Useful for specifying elements of a vector used by chopper-lib
+
+        :mod:`niess.chopcalc` is the maintained path: it reads the emitted instrument
+        rather than a calibration, so it finds choppers nested inside sections, measures
+        flight paths along the beam, and handles discs this method refuses.
+        """
         from scipp import max, min, norm
         speed_name = f'{self.name}speed'
         # chopper-lib wants a phase in degrees; the run-time knob is a delay in seconds,

--- a/tests/test_chopcalc.py
+++ b/tests/test_chopcalc.py
@@ -1,0 +1,342 @@
+"""Only simulate the wavelengths a chopper train can pass.
+
+A source samples uniformly across the band it is given and a chopper train throws most of
+that away, so narrowing the source to the band the train passes is free simulation speed.
+The band depends on chopper speeds and delays, which are run-time parameters, so it cannot
+be computed when the instrument is built -- hence C, emitted into the instrument's
+INITIALIZE, which McCode runs before every component's own initialisation. That ordering
+is the whole trick, and it is why these tests assert against generated text.
+
+The version this replaces lived inline in a BIFROST build script. It walked the top level
+of a niess Section tree, so it found 2 of BIFROST's 6 choppers and narrowed the band to
+[0.75, 10.45] A where the full train admits [0.75, 0.81] A -- safe, since an over-wide
+band only wastes time, but most of the speed-up was left behind.
+"""
+import logging
+
+import pytest
+from mccode_antlr import Flavor
+from mccode_antlr.assembler import Assembler
+from scipp import array, scalar
+
+from niess.chopcalc import ChopcalcError, narrow_source_wavelengths
+
+EDGES = [10.0, 30.0, 100.0, 140.0, 350.0, 370.0]
+
+
+def source_at(assembler, *, lmin='source_lambda_min', lmax='source_lambda_max',
+              declare=True, **extra):
+    if declare:
+        assembler.parameter(f'{lmin}/"angstrom"=0.75')
+        assembler.parameter(f'{lmax}/"angstrom"=30.0')
+    return assembler.component(
+        'source', 'ESS_butterfly', at=((0, 0, 0), 'ABSOLUTE'),
+        parameters={'Lmin': lmin, 'Lmax': lmax, **extra})
+
+
+def one_chopper(**overrides):
+    """A source and a single DiskChopper, with nothing else in the way."""
+    assembler = Assembler('bare', flavor=Flavor.MCSTAS)
+    source_at(assembler)
+    parameters = {'theta_0': 170.0, 'nslit': 1, 'radius': 0.35, 'yheight': 0.06,
+                  'nu': 'chopperspeed', 'delay': 'chopperdelay'}
+    parameters.update(overrides)
+    assembler.parameter('chopperspeed/"Hz"=14.0')
+    assembler.parameter('chopperdelay/"s"=0.0')
+    assembler.component('chopper', 'DiskChopper', at=((0, 0, 6.0), 'source'),
+                        parameters=parameters)
+    return assembler
+
+
+def multi_slit(edges=EDGES):
+    from niess.components import MultiSlitChopper
+    assembler = Assembler('disc', flavor=Flavor.MCSTAS)
+    source_at(assembler)
+    from scipp import vector
+    from scipp.spatial import rotations_from_rotvecs
+    MultiSlitChopper.from_calibration({
+        'name': 'pack',
+        'position': vector([0, 0, 6.0], unit='m'),
+        'orientation': rotations_from_rotvecs(vector([0, 0, 0.0], unit='deg')),
+        'radius': scalar(0.35, unit='m'), 'height': scalar(0.06, unit='m'),
+        'frequency': scalar(14.0, unit='Hz'),
+        'beam_position': scalar(90.0, unit='deg'),
+        'windows': array(values=edges, dims=['edges'], unit='deg'),
+    }).to_mccode(assembler, at='source', rotate='source')
+    return assembler
+
+
+@pytest.fixture
+def teaching():
+    from niess.teaching import Primary
+    assembler = Assembler('teaching', flavor=Flavor.MCSTAS)
+    Primary.from_calibration().to_mccode(assembler)
+    return assembler
+
+
+@pytest.fixture
+def bifrost():
+    from niess.bifrost import Primary
+    from niess.bifrost.parameters import primary_parameters
+    assembler = Assembler('bifrost', flavor=Flavor.MCSTAS)
+    Primary.from_calibration(primary_parameters()).to_mccode(assembler)
+    return assembler
+
+
+# -- what it emits -----------------------------------------------------------
+
+def test_the_band_is_narrowed_through_the_sources_own_parameters(teaching):
+    narrow_source_wavelengths(teaching)
+    text = str(teaching.instrument)
+    assert '&source_lambda_min, &source_lambda_max' in text
+    assert 'chopper_wavelength_limits' in text
+
+
+def test_a_chopper_is_named_not_valued(teaching):
+    """The row references run-time parameters, so the band recomputes without a rebuild."""
+    narrow_source_wavelengths(teaching)
+    assert '{chopperspeed, chopperdelay, 170.0,' in str(teaching.instrument)
+
+
+def test_every_chopper_is_found_however_deeply_it_is_nested(bifrost):
+    """BIFROST hides four of its six choppers inside nested Sections.
+
+    The version this replaces walked ``Primary.items()``, which reaches only top-level
+    fields, and so never saw the frame-overlap or bandwidth pairs -- the ones that
+    actually set the band.
+    """
+    train = narrow_source_wavelengths(bifrost)
+    assert [c.name for c in train.choppers] == [
+        'pulse_shaping_chopper_1', 'pulse_shaping_chopper_2',
+        'frame_overlap_chopper_1', 'frame_overlap_chopper_2',
+        'bandwidth_chopper_1', 'bandwidth_chopper_2',
+    ]
+
+
+def test_the_choppers_come_out_in_beam_order(bifrost):
+    train = narrow_source_wavelengths(bifrost)
+    paths = [float(c.path) for c in train.choppers]
+    assert paths == sorted(paths)
+
+
+def test_the_path_is_walked_along_the_beam(bifrost):
+    """Not chorded from the origin: a curved guide is followed, not cut across."""
+    train = narrow_source_wavelengths(bifrost)
+    walked = {c.name: float(c.path) for c in train.choppers}
+    # the bandwidth choppers sit 78 m away past the curved section
+    assert walked['bandwidth_chopper_1'] > 77.98
+    assert walked['bandwidth_chopper_1'] < 78.0
+
+
+def test_the_latest_emission_time_comes_from_the_source_itself(teaching):
+    """Not the hardcoded 2.0e-4 + 2.86e-3 + 2e-3 the previous version carried."""
+    train = narrow_source_wavelengths(teaching)
+    assert train.source.latest_emission == '3.0 * 0.002857'
+    assert 'tmax_multiplier' in train.source.latest_emission_note
+
+
+def test_evenly_spaced_openings_become_one_faster_chopper():
+    """chopper-lib's own substitution: nslit identical openings at nslit times the speed."""
+    assembler = one_chopper(nslit=3, theta_0=20.0)
+    train = narrow_source_wavelengths(assembler)
+    assert train.choppers[0].speed == '(chopperspeed) * 3.0'
+
+
+def test_a_phase_is_turned_into_a_delay_the_way_diskchopper_does():
+    assembler = one_chopper(phase=45.0)
+    train = narrow_source_wavelengths(assembler)
+    assert train.choppers[0].delay == '(45.0) / (360.0 * fabs(chopperspeed))'
+
+
+def test_the_include_is_guarded_against_chopper_lib_1(teaching):
+    """The struct did not change size when phase became delay, so only a guard catches it."""
+    narrow_source_wavelengths(teaching)
+    text = str(teaching.instrument)
+    assert '%include "chopper-lib"' in text
+    assert 'CHOPPER_LIB_VERSION < 20000' in text
+    assert '#error' in text
+
+
+def test_the_registry_is_added_once(teaching):
+    narrow_source_wavelengths(teaching)
+    names = [r.name for r in teaching.instrument.registries]
+    assert names.count('mcstas-chopper-lib') == 1
+
+
+def test_calling_it_twice_does_not_narrow_twice(teaching, caplog):
+    assert narrow_source_wavelengths(teaching) is not None
+    with caplog.at_level(logging.WARNING):
+        assert narrow_source_wavelengths(teaching) is None
+    assert 'already been narrowed' in caplog.text
+    assert str(teaching.instrument).count('chopcalc_choppers[]') == 1
+
+
+# -- what the generated C does when it fails ---------------------------------
+
+def test_a_train_that_passes_nothing_leaves_the_band_alone(teaching):
+    """chopper_wavelength_limits leaves its outputs untouched on zero.
+
+    Putting the band back makes that a property of this instrument rather than of
+    whichever library version was resolved -- and keeps a degenerate band away from
+    ESS_butterfly, whose own INITIALIZE exits when Lmin >= Lmax.
+    """
+    narrow_source_wavelengths(teaching)
+    text = str(teaching.instrument)
+    assert 'chopcalc_windows == 0' in text
+    assert 'source_lambda_min = chopcalc_min;' in text
+
+
+def test_the_advice_names_delays_not_phases(teaching):
+    """The version this replaces still said "speeds and phases" after 2.0.0 dropped phase."""
+    narrow_source_wavelengths(teaching)
+    text = str(teaching.instrument)
+    assert 'chopper speeds and delays' in text
+    assert 'phases' not in text
+
+
+def test_the_envelope_of_several_bands_says_so(teaching):
+    narrow_source_wavelengths(teaching)
+    assert 'separate bands' in str(teaching.instrument)
+
+
+# -- what it refuses ---------------------------------------------------------
+
+@pytest.mark.parametrize('lmin,lmax,fragment', [
+    (0.75, 30.0, 'not valid C'),
+    ('lambda_lo', 'lambda_hi', 'not a DEFINE INSTRUMENT parameter'),
+], ids=['literal', 'undeclared-name'])
+def test_a_wavelength_limit_that_cannot_be_written_through_is_refused(
+        lmin, lmax, fragment, caplog):
+    assembler = Assembler('bad', flavor=Flavor.MCSTAS)
+    source_at(assembler, lmin=lmin, lmax=lmax, declare=False)
+    assembler.component('chopper', 'DiskChopper', at=((0, 0, 6.0), 'source'),
+                        parameters={'theta_0': 170.0, 'nslit': 1, 'radius': 0.35,
+                                    'yheight': 0.06, 'nu': 14.0, 'delay': 0.0})
+    with caplog.at_level(logging.WARNING):
+        assert narrow_source_wavelengths(assembler) is None
+    assert fragment in caplog.text
+    assert 'chopcalc_choppers' not in str(assembler.instrument)
+
+    with pytest.raises(ChopcalcError, match=fragment):
+        narrow_source_wavelengths(assembler, strict=True)
+
+
+def test_an_instrument_with_no_choppers_emits_nothing(caplog):
+    assembler = Assembler('empty', flavor=Flavor.MCSTAS)
+    source_at(assembler)
+    assembler.component('sample', 'Arm', at=((0, 0, 5.0), 'source'))
+    with caplog.at_level(logging.WARNING):
+        assert narrow_source_wavelengths(assembler) is None
+    assert 'nothing to narrow' in caplog.text
+    assert 'chopcalc_choppers' not in str(assembler.instrument)
+
+
+def test_a_first_chopper_abandons_the_calculation(caplog):
+    """isfirst re-times neutrons rather than absorbing them.
+
+    Every downstream delay is then measured from a different zero, so the chopper-train
+    model does not apply and a band computed from it would be meaningless.
+    """
+    assembler = one_chopper(isfirst=1)
+    with caplog.at_level(logging.WARNING):
+        assert narrow_source_wavelengths(assembler) is None
+    assert 'isfirst' in caplog.text
+
+
+def test_it_must_be_given_the_top_level_assembler(teaching):
+    with teaching.included('teaching_child') as child:
+        with pytest.raises(ChopcalcError, match='top-level Assembler'):
+            narrow_source_wavelengths(child)
+
+
+# -- finding the source ------------------------------------------------------
+
+def test_a_wavelength_monitor_is_not_mistaken_for_the_source():
+    """L_monitor takes Lmin and Lmax too, as do four other monitors.
+
+    Having those parameters is therefore not what makes a component a source. Being where
+    the neutrons enter is, and that is a root of the beam path.
+    """
+    assembler = one_chopper()
+    assembler.component('lambda_monitor', 'L_monitor', at=((0, 0, 8.0), 'source'),
+                        parameters={'nL': 100, 'Lmin': 0.5, 'Lmax': 10.0,
+                                    'xwidth': 0.05, 'yheight': 0.05,
+                                    'filename': '"lambda.dat"'})
+    train = narrow_source_wavelengths(assembler)
+    assert train.source.name == 'source'
+
+
+def test_naming_a_downstream_component_as_the_source_is_refused(caplog):
+    assembler = one_chopper()
+    assembler.component('lambda_monitor', 'L_monitor', at=((0, 0, 8.0), 'source'),
+                        parameters={'nL': 100, 'Lmin': 0.5, 'Lmax': 10.0,
+                                    'xwidth': 0.05, 'yheight': 0.05,
+                                    'filename': '"lambda.dat"'})
+    with caplog.at_level(logging.WARNING):
+        assert narrow_source_wavelengths(assembler, source='lambda_monitor') is None
+    assert 'lambda_monitor' in caplog.text
+
+
+def test_naming_a_component_that_does_not_exist_is_refused(caplog):
+    assembler = one_chopper()
+    with caplog.at_level(logging.WARNING):
+        assert narrow_source_wavelengths(assembler, source='moderator') is None
+    assert "no component named 'moderator'" in caplog.text
+
+
+# -- multi-slit discs --------------------------------------------------------
+
+def test_a_multi_slit_disc_becomes_one_conservative_envelope(caplog):
+    """A disc's acceptance is the union of its openings; chopper-lib intersects.
+
+    One row per opening would demand a neutron clear every opening at once, giving a band
+    too narrow -- the one failure that loses neutrons. The angular envelope admits the
+    gaps between openings too, so the band can only come out wider.
+    """
+    assembler = multi_slit([10.0, 30.0, 40.0, 60.0])
+    with caplog.at_level(logging.WARNING):
+        train = narrow_source_wavelengths(assembler)
+    assert len(train.choppers) == 1
+    assert train.choppers[0].angle == '50.0'
+    # openings centred at 35 degrees, beam at 90, so 55 degrees of turning either way
+    assert '? 305.0 : 55.0' in train.choppers[0].delay
+
+
+def test_a_disc_is_warned_about_once_however_many_openings_it_has(caplog):
+    assembler = multi_slit([10.0, 30.0, 40.0, 60.0])
+    with caplog.at_level(logging.WARNING):
+        narrow_source_wavelengths(assembler)
+    assert caplog.text.count('multi-opening disc') == 1
+    assert 'multi_chopper_inverse_velocity_limits' in caplog.text
+
+
+def test_a_disc_whose_openings_span_a_revolution_constrains_nothing(caplog):
+    assembler = multi_slit(EDGES)
+    with caplog.at_level(logging.WARNING):
+        assert narrow_source_wavelengths(assembler) is None
+    assert 'full revolution' in caplog.text
+
+
+def test_a_grouped_chopper_without_provenance_is_left_out(caplog):
+    """A McStas GROUP makes discs alternatives, not a series.
+
+    Without slit_edges there is nothing to build an envelope from, so it is dropped --
+    which only widens the band.
+    """
+    assembler = one_chopper()
+    assembler.instrument.get_component('chopper').GROUP('pack')
+    with caplog.at_level(logging.WARNING):
+        assert narrow_source_wavelengths(assembler) is None
+    assert 'alternatives rather than a series' in caplog.text
+
+
+def test_the_caller_is_told_what_was_used_and_what_was_not(caplog):
+    """So a build script can assert on the outcome without reading generated C."""
+    assembler = multi_slit(EDGES)
+    with caplog.at_level(logging.WARNING):
+        narrow_source_wavelengths(assembler)
+    assembler = multi_slit([10.0, 30.0, 40.0, 60.0])
+    train = narrow_source_wavelengths(assembler)
+    assert train.source.name == 'source'
+    assert train.choppers[0].name == 'pack'
+    assert 'envelope' in train.choppers[0].note

--- a/zensical.toml
+++ b/zensical.toml
@@ -18,6 +18,7 @@ nav = [
     { "Translate a McStas .instr" = "how-to/translate-an-instr.md" },
     { "Build a new instrument submodule" = "how-to/new-instrument-submodule.md" },
     { "Produce NeXus Structure JSON" = "how-to/nexus-structure.md" },
+    { "Narrow the wavelength band" = "how-to/narrow-the-wavelength-band.md" },
     { "Write NeXus translators" = "how-to/custom-nexus-registry.md" },
   ] },
   { "Reference" = [


### PR DESCRIPTION
A source samples uniformly across the band it is given and a chopper train throws most of that away, so every neutron absorbed at the first chopper cost something to create. Narrowing the source to the band the train passes is free simulation speed.

The band depends on chopper speeds and delays, which are run-time parameters, so it cannot be worked out while the instrument is being built. niess.chopcalc emits a call to chopper-lib into the instrument's INITIALIZE instead, which McCode runs before every component's own initialisation -- so the source reads the narrowed values, and changing a delay on the command line recomputes the band without rebuilding anything.

This existed already, inline in a BIFROST build script and again in a chopper-lib test. Both walked the top level of a niess Section tree, so they found 2 of BIFROST's 6 choppers -- missing the bandwidth pair that actually sets the band. Reading the assembled instrument instead finds all six wherever they were nested, and assumes no naming convention: nu, delay, theta_0 and nslit come off each emitted DiskChopper, and the source's own Lmin/Lmax name the parameters to narrow.

The source is found from the beam path rather than from its parameters or its category. Neither of those works: get_component_names_by_category('sources') returns nothing, and five monitors take Lmin and Lmax, so a wavelength monitor would answer to that test. Being where the neutrons enter is what makes a source, and that is a root of the particle flow graph.

Flight paths are walked along that same graph, so a curved guide is followed rather than chorded. A chopper's emitted AT is already where the beam crosses its disc, so the endpoints need no correction -- but a disc placed at its spindle instead would inflate its own path silently, so an arrival that bends the beam more than a degree is warned about. BIFROST's choppers measure 0.0000 degrees there; a disc 0.35 m off the beam measures 6.15.

A multi-opening disc is approximated rather than dropped. chopper-lib intersects chopper acceptances while a disc's openings are alternatives, so a row per opening would demand a neutron clear every one at once -- a band too narrow, which is the single failure that loses neutrons. Its angular envelope is used instead, admitting the gaps between openings too, and it warns every time: the right answer is a multi_chopper_inverse_velocity_limits that chopper-lib does not have yet.

Everything else it leaves out only widens the band, so none of it can be wrong: a Fermi chopper, a disc in a bare McStas GROUP, one whose speed or delay is unset. A chopper with isfirst=1 stops the calculation altogether, since it re-times neutrons rather than absorbing them and every downstream delay is then measured from a different zero.

Verified against a compiled instrument, not only in Python: the emitted C narrows 0.5-10 AA to 1.7237, 2.51491 and 3.30611 AA at delays of 4, 6 and 8 ms, matching chopper-lib called independently from Python to five decimals, and moving with a delay given on the command line. The version guard fires against a 1.x library, where the struct is the same size but its second field meant a phase in degrees.